### PR TITLE
[codex] Stabilize Komiku public scrapers

### DIFF
--- a/controllers/bacaChapterController.js
+++ b/controllers/bacaChapterController.js
@@ -1,247 +1,192 @@
-const express = require("express");
-const axios = require("axios");
 const cheerio = require("cheerio");
-const router = express.Router();
-
-const URL_BASE = "https://komiku.org/"; // Renamed for clarity
+const {
+  BASE_URL,
+  fetchHtml,
+  getAbsoluteUrl,
+  normalizeText,
+  getImageUrl,
+  extractMangaSlug,
+  extractChapterNumber,
+  extractChapterSlug,
+  logEmptyParse,
+} = require("./scraperUtils");
 
 function extractSlugAndChapter(url) {
-  // Regex to match URLs like /slug-chapter-123/ or /manga/slug/chapter/123/ (more flexible)
-  const matches =
-    url.match(/\/([^\/]+?)-chapter-([^\/]+?)(?:\/|$)/) ||
-    url.match(/\/manga\/[^\/]+\/chapter\/([^\/]+?)(?:\/|$)/);
-  if (matches && matches[1] && matches[2]) {
-    return {
-      slug: matches[1],
-      chapter: matches[2],
-    };
-  } else if (url.includes("-chapter-")) {
-    // Fallback for simpler /slug-chapter-num/ pattern
-    const parts = url.split("/");
-    const chapterPart = parts.find((part) => part.includes("-chapter-"));
-    if (chapterPart) {
-      const chapterMatch = chapterPart.match(/^(.*?)-chapter-(.*?)$/);
-      if (chapterMatch && chapterMatch[1] && chapterMatch[2]) {
-        return {
-          slug: chapterMatch[1],
-          chapter: chapterMatch[2],
-        };
+  const absoluteUrl = getAbsoluteUrl(url);
+  return {
+    slug: extractChapterSlug(absoluteUrl),
+    chapter: extractChapterNumber(absoluteUrl),
+  };
+}
+
+function getChapterInfo(link, currentSlug = "") {
+  if (!link) return null;
+
+  const originalLink = getAbsoluteUrl(link);
+  const slug = extractChapterSlug(originalLink) || currentSlug;
+  const chapter = extractChapterNumber(originalLink);
+
+  return slug && chapter
+    ? {
+        originalLink,
+        apiLink: `/baca-chapter/${slug}/${chapter}`,
+        slug,
+        chapter,
       }
-    }
-  }
-  return { slug: "", chapter: "" };
+    : null;
+}
+
+function getDescription($) {
+  const descriptionText = normalizeText($("#Description").first().text());
+  if (descriptionText) return descriptionText;
+
+  return normalizeText(
+    $("p")
+      .filter((_, el) => /Baca online|update di Komiku/i.test($(el).text()))
+      .first()
+      .text()
+  );
 }
 
 const getBacaChapter = async (req, res) => {
   try {
     const { slug, chapter } = req.params;
-    const chapterUrl = `${URL_BASE}${slug}-chapter-${chapter}/`;
-
-    const { data } = await axios.get(chapterUrl, {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-        Accept:
-          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.5",
-        Referer: "https://komiku.id/",
-        "Cache-Control": "public, max-age=3600", // Cache for 1 hour
-        timeout: 10000, // Optional: 10 seconds timeout
-      },
-    });
-
+    const chapterUrl = `${BASE_URL}/${slug}-chapter-${chapter}/`;
+    const data = await fetchHtml(chapterUrl);
     const $ = cheerio.load(data);
 
-    const breadcrumb = []; // Kept for potential future use, but commented out in response
-    $("#breadcrumb li").each((i, el) => {
-      const text = $(el).find("span").text().trim();
-      const link = $(el).find("a").attr("href");
-
-      let detailLink = null;
-      if (link && link.includes("/manga/")) {
-        const matches = link.match(/\/manga\/([^/]+)/);
-        if (matches && matches[1]) {
-          detailLink = `/detail-komik/${matches[1]}`;
-        }
-      }
-
-      breadcrumb.push({
-        text,
-        originalLink: link || "",
-        apiLink: detailLink,
-      });
-    });
-
-    const title = $("#Judul h1").text().trim();
-    const mangaTitleElement = $("#Judul p a b");
-    const mangaTitle = mangaTitleElement.text().trim();
-    const mangaLink = mangaTitleElement.parent().attr("href"); // Get href from parent <a> of <b>
-    const description =
-      $("#Description")
-        .first()
-        .contents()
-        .filter(function () {
-          return this.type === "text";
-        })
-        .text()
-        .trim() +
-      " " +
-      $("#Description b").first().text().trim() +
-      " " +
-      $("#Description a[href='/'] b").first().text().trim();
-
-    let mangaSlug = "";
-    if (mangaLink) {
-      const mangaMatches = mangaLink.match(/\/manga\/([^/]+)/);
-      if (mangaMatches && mangaMatches[1]) {
-        mangaSlug = mangaMatches[1];
-      }
-    }
+    const title =
+      normalizeText($("#Judul h1").first().text()) ||
+      normalizeText($("h1").first().text()) ||
+      normalizeText($("meta[itemprop='name']").attr("content"));
+    const mangaTitleElement = $(
+      '#Judul a[href*="/manga/"], a[href*="/manga/"]'
+    ).first();
+    const mangaTitle =
+      normalizeText(mangaTitleElement.find("b").first().text()) ||
+      normalizeText(mangaTitleElement.text()) ||
+      normalizeText(mangaTitleElement.attr("title"));
+    const mangaLink = getAbsoluteUrl(mangaTitleElement.attr("href"));
+    const mangaSlug = extractMangaSlug(mangaLink);
 
     const chapterInfo = {};
-    $("#Judul table.tbl tbody tr").each((i, el) => {
-      const key = $(el).find("td").first().text().trim();
-      const value = $(el).find("td").last().text().trim();
-      chapterInfo[key] = value;
+    $("#Judul table tr, table.tbl tr").each((_, el) => {
+      const cells = $(el).find("td, th");
+      const key = normalizeText(cells.first().text()).replace(/:$/, "");
+      const value = normalizeText(cells.last().text());
+      if (key && value && key !== value) chapterInfo[key] = value;
     });
 
     const images = [];
-    $("#Baca_Komik img").each((i, el) => {
-      const src = $(el).attr("src");
-      const alt = $(el).attr("alt");
-      const id = $(el).attr("id");
+    $("#Baca_Komik img, img.ww, img[id]").each((_, el) => {
+      const img = $(el);
+      const src = getImageUrl($, img);
+      const id = normalizeText(img.attr("id"));
 
-      // Revised condition to correctly match image URLs from komiku.id's upload directories
       if (
         src &&
-        (src.includes("komiku.org/upload") ||
-          src.includes("cdn.komiku.org/upload") ||
-          src.includes("img.komiku.org/upload")) &&
-        id
+        /(?:img|cdn|komiku)\.komiku\.org\/upload/i.test(src) &&
+        (!id || /^\d+$/.test(id))
       ) {
         images.push({
           src,
-          alt,
+          alt: normalizeText(img.attr("alt")),
           id,
-          fallbackSrc: src
-            .replace("cdn.komiku.id", "img.komiku.id")
-            .replace("komiku.id/upload", "img.komiku.id/upload"), // More robust fallback
+          fallbackSrc: src.replace("cdn.komiku.org", "img.komiku.org"),
         });
       }
     });
 
-    const chapterValueInfo = $(".chapterInfo").attr("valuechapter") || "";
+    const uniqueImages = images.filter(
+      (image, index, allImages) =>
+        image.src && allImages.findIndex((item) => item.src === image.src) === index
+    );
+
+    const navigationLinks = $("#Judul")
+      .parent()
+      .find('a[href*="chapter"]')
+      .toArray()
+      .map((el) => getAbsoluteUrl($(el).attr("href")))
+      .filter(Boolean);
+
+    const currentChapterNumber = parseFloat(chapter);
+    const chapterCandidates = [
+      ...new Set(
+        navigationLinks.filter(
+          (link) =>
+            extractChapterSlug(link) === slug &&
+            extractChapterNumber(link) !== String(chapter)
+        )
+      ),
+    ];
+
+    const prevLink =
+      chapterCandidates
+        .filter((link) => parseFloat(extractChapterNumber(link)) < currentChapterNumber)
+        .sort(
+          (a, b) =>
+            parseFloat(extractChapterNumber(b)) -
+            parseFloat(extractChapterNumber(a))
+        )[0] || "";
+    const nextLink =
+      chapterCandidates
+        .filter((link) => parseFloat(extractChapterNumber(link)) > currentChapterNumber)
+        .sort(
+          (a, b) =>
+            parseFloat(extractChapterNumber(a)) -
+            parseFloat(extractChapterNumber(b))
+        )[0] || "";
+
+    const chapterValueInfo =
+      $(".chapterInfo").attr("valuechapter") ||
+      extractChapterNumber(chapterUrl) ||
+      chapter;
     const totalImages =
-      $(".chapterInfo").attr("valuegambar") || images.length.toString();
+      $(".chapterInfo").attr("valuegambar") || uniqueImages.length.toString();
     const viewAnalyticsUrl = $(".chapterInfo").attr("valueview") || "";
-    const additionalDescription = $("#Komentar p").first().text().trim();
+    const additionalDescription = normalizeText($("#Komentar p").first().text());
     const publishDate =
       $("time[property='datePublished']").attr("datetime") ||
-      $("time").first().text().trim();
+      $("meta[itemprop='datePublished']").attr("content") ||
+      normalizeText($("time").first().text());
 
-    // Revised selectors for previous and next chapter links
-    // These links are often within a specific navigation bar, e.g., #set<chapter_id> .nxpr
-    // Using a more general approach first, then trying specific if needed.
-    // The provided HTML uses #set<numbers> as ID for the floating nav bar.
-    // We target links within .nxpr which usually holds prev/next/all_chapters links.
+    if (!title || !uniqueImages.length) {
+      logEmptyParse("GET /baca-chapter", data, {
+        target: chapterUrl,
+        titleFound: !!title,
+        imagesFound: uniqueImages.length,
+        selectors: "#Judul h1, #Baca_Komik img, img.ww",
+      });
 
-    let prevChapterLink = "";
-    // Komiku uses a link with class 'rl' (read left) for previous chapter
-    // It's usually inside a div with class 'nxpr' in a floating menu (e.g., id="setxxxxx")
-    const prevLinkElement = $(".nxpr a.rl[href*='-chapter-']");
-    if (prevLinkElement.length > 0) {
-      prevChapterLink = prevLinkElement.attr("href");
-    } else {
-      // Fallback if the specific structure changed, less reliable
-      // This was your original, which might be too broad or rely on text not present
-      // prevChapterLink = $("a:contains('Chapter Sebelumnya')").attr("href") || "";
-    }
-
-    let nextChapterLink = "";
-    // Komiku might use 'rr' (read right) or it's the other chapter link in .nxpr
-    const nextLinkElementRR = $(".nxpr a.rr[href*='-chapter-']");
-    if (nextLinkElementRR.length > 0) {
-      nextChapterLink = nextLinkElementRR.attr("href");
-    } else {
-      // Fallback: Find any link in .nxpr that looks like a chapter link and isn't the previous one or the all chapters list
-      $(".nxpr a[href*='-chapter-']").each((i, el) => {
-        const potentialNextHref = $(el).attr("href");
-        if (potentialNextHref !== prevChapterLink) {
-          nextChapterLink = potentialNextHref;
-          return false; // Found a potential next link
-        }
+      return res.status(502).json({
+        error: "Gagal parsing data chapter komik dari Komiku.",
+        detail:
+          "Struktur HTML chapter kemungkinan berubah atau gambar chapter kosong.",
       });
     }
 
-    let prevChapterInfo = null;
-    if (prevChapterLink) {
-      const { slug: prevSlug, chapter: prevChapter } =
-        extractSlugAndChapter(prevChapterLink);
-      if (prevSlug && prevChapter) {
-        prevChapterInfo = {
-          originalLink: prevChapterLink.startsWith("http")
-            ? prevChapterLink
-            : `${URL_BASE}${
-                prevChapterLink.startsWith("/")
-                  ? prevChapterLink.substring(1)
-                  : prevChapterLink
-              }`,
-          apiLink: `/baca-chapter/${prevSlug}/${prevChapter}`,
-          slug: prevSlug,
-          chapter: prevChapter,
-        };
-      }
-    }
-
-    let nextChapterInfo = null;
-    if (nextChapterLink) {
-      const { slug: nextSlug, chapter: nextChapter } =
-        extractSlugAndChapter(nextChapterLink);
-      if (nextSlug && nextChapter) {
-        nextChapterInfo = {
-          originalLink: nextChapterLink.startsWith("http")
-            ? nextChapterLink
-            : `${URL_BASE}${
-                nextChapterLink.startsWith("/")
-                  ? nextChapterLink.substring(1)
-                  : nextChapterLink
-              }`,
-          apiLink: `/baca-chapter/${nextSlug}/${nextChapter}`,
-          slug: nextSlug,
-          chapter: nextChapter,
-        };
-      }
-    }
-
     res.json({
-      // breadcrumb, // Uncomment if needed
       title,
       mangaInfo: {
         title: mangaTitle,
-        originalLink: mangaLink?.startsWith("http")
-          ? mangaLink
-          : mangaLink
-          ? `${URL_BASE}${
-              mangaLink.startsWith("/") ? mangaLink.substring(1) : mangaLink
-            }`
-          : null,
+        originalLink: mangaLink,
         apiLink: mangaSlug ? `/detail-komik/${mangaSlug}` : null,
         slug: mangaSlug,
       },
-      description,
+      description: getDescription($),
       chapterInfo,
-      images,
+      images: uniqueImages,
       meta: {
-        chapterNumber: chapterValueInfo || chapter,
-        totalImages: parseInt(totalImages) || 0,
+        chapterNumber: chapterValueInfo,
+        totalImages: parseInt(totalImages, 10) || 0,
         publishDate,
         viewAnalyticsUrl,
-        slug: slug, // current slug
+        slug,
       },
       navigation: {
-        prevChapter: prevChapterInfo,
-        nextChapter: nextChapterInfo,
-        allChapters: mangaSlug ? `/detail-komik/${mangaSlug}` : null, // Link to see all chapters, typically the manga detail page
+        prevChapter: getChapterInfo(prevLink, slug),
+        nextChapter: getChapterInfo(nextLink, slug),
+        allChapters: mangaSlug ? `/detail-komik/${mangaSlug}` : null,
       },
       additionalDescription,
     });
@@ -255,39 +200,4 @@ const getBacaChapter = async (req, res) => {
   }
 };
 
-router.get("/url", async (req, res) => {
-  try {
-    const { url } = req.query;
-
-    if (!url) {
-      return res.status(400).json({
-        error: "URL parameter diperlukan",
-      });
-    }
-
-    if (!url.includes("komiku.id/") || !url.includes("chapter")) {
-      return res.status(400).json({
-        error: "URL tidak valid, harus dari komiku.id dan berisi 'chapter'",
-      });
-    }
-
-    const { slug, chapter } = extractSlugAndChapter(url);
-
-    if (!slug || !chapter) {
-      return res.status(400).json({
-        error: "URL tidak valid, tidak bisa mengekstrak slug dan nomor chapter",
-      });
-    }
-    // Redirect to the main route
-    return res.redirect(`/baca-chapter/${slug}/${chapter}`);
-  } catch (err) {
-    console.error("Error fetching chapter from URL:", err);
-    res.status(500).json({
-      error: "Gagal mengambil data chapter komik dari URL",
-      detail: err.message,
-      stack: process.env.NODE_ENV === "development" ? err.stack : undefined,
-    });
-  }
-});
-
-module.exports = { getBacaChapter };
+module.exports = { getBacaChapter, extractSlugAndChapter };

--- a/controllers/berwarnaController.js
+++ b/controllers/berwarnaController.js
@@ -1,158 +1,132 @@
-const express = require("express");
-const router = express.Router();
-const axios = require("axios");
 const cheerio = require("cheerio");
+const {
+  BASE_URL,
+  fetchHtml,
+  getAbsoluteUrl,
+  normalizeText,
+  cleanTitle,
+  getImageUrl,
+  extractMangaSlug,
+  getApiChapterLink,
+  logEmptyParse,
+} = require("./scraperUtils");
 
 console.log("Loading berwarna route for Express 5...");
 
-// Function to get random delay between 1-3 seconds
-const getRandomDelay = () =>
-  Math.floor(Math.random() * (3000 - 1000 + 1) + 1000);
+async function getBerwarnaHtml(page) {
+  const validPage = Math.max(1, parseInt(page, 10) || 1);
+  const pageUrl =
+    validPage === 1
+      ? `${BASE_URL}/other/berwarna/`
+      : `${BASE_URL}/other/berwarna/page/${validPage}/`;
+  const shellHtml = await fetchHtml(pageUrl);
+  const $shell = cheerio.load(shellHtml);
+  const htmxUrl = $shell("[hx-get], [data-hx-get]").first().attr("hx-get");
 
-// Function to get random user agent
-const getRandomUserAgent = () => {
-  const userAgents = [
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0",
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Safari/605.1.15",
-  ];
-  return userAgents[Math.floor(Math.random() * userAgents.length)];
-};
-
-// Function to extract slug from URL
-const extractSlug = (url) => {
-  if (!url || typeof url !== "string") return "";
-  try {
-    const matches = url.match(/\/manga\/(.*?)\//);
-    return matches && matches[1] ? matches[1] : "";
-  } catch (error) {
-    console.error("Error extracting slug:", error);
-    return "";
-  }
-};
-
-// Add this helper function to format chapter URL
-const formatChapterUrl = (url) => {
-  // Extract the manga title and chapter number
-  const match = url.match(/\/([^/]+)-chapter-(\d+)/);
-  if (match) {
-    const [, title, chapter] = match;
-    return `/baca-chapter/${title}/${chapter}`;
-  }
-  return url;
-};
-
-// Function to scrape manga data from a given page
-async function scrapeBerwarna(page = 1) {
-  try {
-    console.log(`Scraping berwarna page ${page}...`);
-
-    // Validate page parameter
-    const validPage = Math.max(1, parseInt(page) || 1);
-
-    // Add delay before request
-    await new Promise((resolve) => setTimeout(resolve, getRandomDelay()));
-
-    const url =
-      validPage === 1
-        ? "https://api.komiku.org/other/berwarna/"
-        : `https://api.komiku.org/other/berwarna/page/${validPage}/`;
-
-    console.log(`Requesting URL: ${url}`);
-
-    const response = await axios.get(url, {
-      headers: {
-        "User-Agent": getRandomUserAgent(),
-        Accept:
-          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.5",
-        "Accept-Encoding": "gzip, deflate, br",
-        Connection: "keep-alive",
-        "Upgrade-Insecure-Requests": "1",
-        "Cache-Control": "max-age=0",
-        Referer: "https://komiku.org/",
-      },
-      timeout: 15000,
-      maxRedirects: 5,
+  if (!htmxUrl) {
+    logEmptyParse("GET /berwarna shell", shellHtml, {
+      target: pageUrl,
+      selector: "[hx-get], [data-hx-get]",
     });
-
-    const $ = cheerio.load(response.data);
-    const mangaList = [];
-
-    $(".bge").each((i, element) => {
-      try {
-        const $el = $(element);
-        const url = $el.find(".bgei a").attr("href") || "";
-        const slug = extractSlug(url);
-
-        // Get chapter elements
-        const firstChapterElement = $el.find(".new1 a").first();
-        const lastChapterElement = $el.find(".new1 a").last();
-
-        const manga = {
-          title: $el.find("h3").text().trim() || `Manga ${i + 1}`,
-          thumbnail: $el.find(".sd").attr("src") || "",
-          type: $el.find(".tpe1_inf b").text().trim() || "Unknown",
-          genre:
-            $el
-              .find(".tpe1_inf")
-              .text()
-              .replace($el.find(".tpe1_inf b").text(), "")
-              .trim() || "",
-          url: url,
-          detailUrl: slug ? `/detail-komik/${slug}` : "",
-          description: $el.find(".kan p").text().trim() || "",
-          stats: $el.find(".judul2").text().trim() || "",
-          firstChapter: firstChapterElement.length
-            ? {
-                title: firstChapterElement.attr("title") || "",
-                url: formatChapterUrl(firstChapterElement.attr("href") || ""),
-              }
-            : null,
-          latestChapter: lastChapterElement.length
-            ? {
-                title: lastChapterElement.attr("title") || "",
-                url: formatChapterUrl(lastChapterElement.attr("href") || ""),
-              }
-            : null,
-        };
-
-        mangaList.push(manga);
-      } catch (elementError) {
-        console.error(`Error processing element ${i}:`, elementError.message);
-      }
-    });
-
-    console.log(
-      `Successfully scraped ${mangaList.length} manga from page ${validPage}`
-    );
-
-    return {
-      page: validPage,
-      results: mangaList,
-      total: mangaList.length,
-      success: true,
-    };
-  } catch (error) {
-    console.error("Error scraping manga:", error.message);
-    throw new Error(
-      `Failed to scrape data from page ${page}: ${error.message}`
-    );
+    return { html: shellHtml, pageUrl, htmxUrl: null, validPage };
   }
+
+  const html = await fetchHtml(htmxUrl, {
+    headers: {
+      "HX-Request": "true",
+      Referer: pageUrl,
+    },
+  });
+
+  return { html, pageUrl, htmxUrl: getAbsoluteUrl(htmxUrl), validPage };
 }
 
-// ROUTES - Express 5 compatible (NO REGEX PATTERNS)
+function parseCard($, el) {
+  const card = $(el);
+  const mangaLinkElement =
+    card.find('h3 a[href*="/manga/"], h2 a[href*="/manga/"], h4 a[href*="/manga/"]').first()
+      .length
+      ? card.find('h3 a[href*="/manga/"], h2 a[href*="/manga/"], h4 a[href*="/manga/"]').first()
+      : card.find('a[href*="/manga/"]').first();
+  const url = getAbsoluteUrl(mangaLinkElement.attr("href"));
+  const slug = extractMangaSlug(url);
+  const img = card.find('a[href*="/manga/"] img, img').first();
+  const type = normalizeText(card.find(".tpe1_inf b, .tpe1_inf strong").first().text());
+  const typeGenreText = normalizeText(card.find(".tpe1_inf").first().text());
+  const chapterLinks = card.find('a[href*="chapter"]').toArray();
+  const firstChapterElement = chapterLinks.length ? $(chapterLinks[0]) : null;
+  const latestChapterElement = chapterLinks.length
+    ? $(chapterLinks[chapterLinks.length - 1])
+    : null;
 
-// Route untuk halaman pertama
+  return {
+    title:
+      cleanTitle(card.find("h3, h2, h4").first().text()) ||
+      cleanTitle(mangaLinkElement.attr("title")) ||
+      cleanTitle(img.attr("alt")),
+    thumbnail: getImageUrl($, img),
+    type: type || "Unknown",
+    genre: typeGenreText.replace(type, "").trim(),
+    url,
+    detailUrl: slug ? `/detail-komik/${slug}` : "",
+    description: normalizeText(card.find("p").first().text()),
+    stats: normalizeText(card.find(".judul2").first().text()),
+    firstChapter: firstChapterElement
+      ? {
+          title:
+            normalizeText(firstChapterElement.attr("title")) ||
+            normalizeText(firstChapterElement.text()),
+          url: getApiChapterLink(firstChapterElement.attr("href")),
+        }
+      : null,
+    latestChapter: latestChapterElement
+      ? {
+          title:
+            normalizeText(latestChapterElement.attr("title")) ||
+            normalizeText(latestChapterElement.text()),
+          url: getApiChapterLink(latestChapterElement.attr("href")),
+        }
+      : null,
+  };
+}
+
+async function scrapeBerwarna(page = 1) {
+  const { html, pageUrl, htmxUrl, validPage } = await getBerwarnaHtml(page);
+  const $ = cheerio.load(html);
+  const seen = new Set();
+  const results = $('.bge:has(a[href*="/manga/"]), article:has(a[href*="/manga/"])')
+    .toArray()
+    .map((el) => parseCard($, el))
+    .filter((item) => {
+      const slug = extractMangaSlug(item.url);
+      if (!item.title || !item.thumbnail || !slug || seen.has(slug)) return false;
+      seen.add(slug);
+      return true;
+    });
+
+  if (!results.length) {
+    logEmptyParse("GET /berwarna", html, {
+      target: htmxUrl || pageUrl,
+      selector: '.bge/article + a[href*="/manga/"]',
+    });
+  }
+
+  return {
+    page: validPage,
+    results,
+    total: results.length,
+    success: true,
+  };
+}
+
 const berwarnaController = {
   getBerwarnaList: async (req, res) => {
     try {
-      console.log("GET /berwarna - fetching page 1");
       const data = await scrapeBerwarna(1);
       res.json({
         status: true,
         message: "Success",
-        data: data,
+        data,
       });
     } catch (error) {
       console.error("Route /berwarna error:", error.message);
@@ -165,14 +139,10 @@ const berwarnaController = {
     }
   },
 
-  // Route dengan parameter sederhana (tanpa regex)
   getBerwarnaByPage: async (req, res) => {
     try {
       const pageParam = req.params.page;
-      console.log(`GET /berwarna/${pageParam}`);
-
-      // Manual validation untuk memastikan parameter adalah angka
-      const pageNum = parseInt(pageParam);
+      const pageNum = parseInt(pageParam, 10);
 
       if (isNaN(pageNum) || pageNum < 1 || !Number.isInteger(pageNum)) {
         return res.status(400).json({
@@ -187,7 +157,7 @@ const berwarnaController = {
       res.json({
         status: true,
         message: "Success",
-        data: data,
+        data,
       });
     } catch (error) {
       console.error("Route /berwarna/:page error:", error.message);

--- a/controllers/detailKomikController.js
+++ b/controllers/detailKomikController.js
@@ -1,242 +1,214 @@
-const express = require("express");
-const axios = require("axios");
 const cheerio = require("cheerio");
-const router = express.Router();
+const {
+  BASE_URL,
+  fetchHtml,
+  getAbsoluteUrl,
+  normalizeText,
+  cleanTitle,
+  getImageUrl,
+  extractMangaSlug,
+  extractChapterNumber,
+  extractChapterSlug,
+  logEmptyParse,
+} = require("./scraperUtils");
 
-const URL = "https://komiku.org/";
+function getChapterApiLink(chapterLink) {
+  const chapterSlug = extractChapterSlug(chapterLink);
+  const chapterNumber = extractChapterNumber(chapterLink);
+  return chapterSlug && chapterNumber
+    ? `/baca-chapter/${chapterSlug}/${chapterNumber}`
+    : null;
+}
+
+function parseChapterLink($, linkElement) {
+  const originalLink = getAbsoluteUrl(linkElement.attr("href"));
+  const title =
+    normalizeText(linkElement.find("span").last().text()) ||
+    normalizeText(linkElement.text()) ||
+    normalizeText(linkElement.attr("title"));
+
+  return {
+    title,
+    originalLink,
+    apiLink: getChapterApiLink(originalLink),
+    chapterNumber: extractChapterNumber(originalLink),
+  };
+}
+
+function findLabeledChapterLink($, label) {
+  const candidates = $("#Judul div, section#Informasi div")
+    .toArray()
+    .filter((el) => normalizeText($(el).text()).startsWith(label))
+    .sort(
+      (a, b) => normalizeText($(a).text()).length - normalizeText($(b).text()).length
+    );
+
+  return candidates.length
+    ? $(candidates[0]).find('a[href*="chapter"]').first()
+    : $();
+}
 
 async function scrapeKomikDetail(url) {
-  try {
-    const { data } = await axios.get(url, {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-        Accept:
-          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.5",
-        Referer: "https://komiku.id/",
-        "Cache-Control": "public, max-age=3600",
-      },
-      timeout: 10000, // Timeout 10 detik
-    });
+  const data = await fetchHtml(url);
+  const $ = cheerio.load(data);
 
-    const $ = cheerio.load(data);
-
-    const title = $("h1 span[itemprop='name']").text().trim();
-    const alternativeTitle = $("p.j2").text().trim();
-    const description = $("p.desc").text().trim();
-    const sinopsis = $("section#Sinopsis p").text().trim();
-
-    const thumbnail = $("section#Informasi div.ims img").attr("src");
-
-    const infoTable = {};
-    $("section#Informasi table.inftable tr").each((i, el) => {
-      const key = $(el).find("td").first().text().trim();
-      const value = $(el).find("td").last().text().trim();
-      infoTable[key] = value;
-    });
-
-    const genres = [];
-    $("section#Informasi ul.genre li").each((i, el) => {
-      genres.push($(el).text().trim());
-    });
-
-    let komikSlug = "";
-    const urlMatches = url.match(/\/manga\/([^/]+)/);
-    if (urlMatches && urlMatches[1]) {
-      komikSlug = urlMatches[1];
-    }
-
-    const firstChapterLink = $("#Judul div.new1:contains('Awal:') a").attr(
-      "href"
-    );
-    const latestChapterLink = $("#Judul div.new1:contains('Terbaru:') a").attr(
-      "href"
+  const title =
+    normalizeText($("h1 [itemprop='name']").first().text()) ||
+    normalizeText($("h1").first().text());
+  const alternativeTitle = normalizeText($("p.j2").first().text());
+  const description = normalizeText($("p.desc").first().text());
+  const sinopsis =
+    normalizeText($("section#Sinopsis p").first().text()) ||
+    normalizeText(
+      $("section")
+        .filter((_, el) => /sinopsis/i.test(normalizeText($(el).text())))
+        .find("p")
+        .first()
+        .text()
     );
 
-    let firstChapterSlug = "";
-    let firstChapterNumber = "";
-    if (firstChapterLink) {
-      const chapterMatches = firstChapterLink.match(
-        /\/([^/]+)-chapter-([^/]+)\//
-      );
-      if (chapterMatches && chapterMatches[1] && chapterMatches[2]) {
-        firstChapterSlug = chapterMatches[1];
-        firstChapterNumber = chapterMatches[2];
-      }
+  const thumbnail =
+    getImageUrl($, $("section#Informasi img").first()) ||
+    getAbsoluteUrl($("meta[itemprop='image']").attr("content")) ||
+    getImageUrl($, $("article img").first());
+
+  const infoTable = {};
+  $("section#Informasi table tr, section#Informasi .inftable tr").each(
+    (_, el) => {
+      const cells = $(el).find("td, th");
+      const key = normalizeText(cells.first().text()).replace(/:$/, "");
+      const value = normalizeText(cells.last().text());
+      if (key && value && key !== value) infoTable[key] = value;
     }
+  );
 
-    let latestChapterSlug = "";
-    let latestChapterNumber = "";
-    if (latestChapterLink) {
-      const chapterMatches = latestChapterLink.match(
-        /\/([^/]+)-chapter-([^/]+)\//
-      );
-      if (chapterMatches && chapterMatches[1] && chapterMatches[2]) {
-        latestChapterSlug = chapterMatches[1];
-        latestChapterNumber = chapterMatches[2];
-      }
-    }
+  const genres = [
+    ...new Set(
+      [
+        ...$("section#Informasi a[href*='/genre/'], section#Informasi ul.genre li")
+          .toArray()
+          .map((el) => normalizeText($(el).text())),
+        ...$("meta[itemprop='genre']")
+          .toArray()
+          .map((el) => normalizeText($(el).attr("content"))),
+      ].filter(Boolean)
+    ),
+  ];
 
-    const firstChapter = {
-      title: $("#Judul div.new1:contains('Awal:') a")
-        .text()
-        .replace("Awal:", "")
-        .trim(),
-      originalLink: firstChapterLink,
-      apiLink:
-        firstChapterSlug && firstChapterNumber
-          ? `/baca-chapter/${firstChapterSlug}/${firstChapterNumber}`
-          : null,
-      chapterNumber: firstChapterNumber,
-    };
+  const komikSlug = extractMangaSlug(url);
+  const firstChapterElement = findLabeledChapterLink($, "Awal:");
+  const latestChapterElement = findLabeledChapterLink($, "Terbaru:");
 
-    const latestChapter = {
-      title: $("#Judul div.new1:contains('Terbaru:') a")
-        .text()
-        .replace("Terbaru:", "")
-        .trim(),
-      originalLink: latestChapterLink,
-      apiLink:
-        latestChapterSlug && latestChapterNumber
-          ? `/baca-chapter/${latestChapterSlug}/${latestChapterNumber}`
-          : null,
-      chapterNumber: latestChapterNumber,
-    };
+  const firstChapter = parseChapterLink($, firstChapterElement);
+  const latestChapter = parseChapterLink($, latestChapterElement);
 
-    const chapters = [];
-    $("table#Daftar_Chapter tbody tr").each((i, el) => {
-      if ($(el).find("th").length > 0) return;
+  const chapters = [];
+  const chapterRows = $("section#Chapter table tr, table#Daftar_Chapter tr")
+    .toArray()
+    .filter((el) => $(el).find('a[href*="chapter"]').length);
 
-      const chapterTitle = $(el).find("td.judulseries a span").text().trim();
-      const chapterLink = $(el).find("td.judulseries a").attr("href");
-      const views = $(el).find("td.pembaca i").text().trim();
-      const date = $(el).find("td.tanggalseries").text().trim();
-
-      let chapterSlug = "";
-      let chapterNumber = "";
-      if (chapterLink) {
-        const chapterMatches = chapterLink.match(/\/([^/]+)-chapter-([^/]+)\//);
-        if (chapterMatches && chapterMatches[1] && chapterMatches[2]) {
-          chapterSlug = chapterMatches[1];
-          chapterNumber = chapterMatches[2];
-        }
-      }
-
-      chapters.push({
-        title: chapterTitle,
-        originalLink: chapterLink,
-        apiLink:
-          chapterSlug && chapterNumber
-            ? `/baca-chapter/${chapterSlug}/${chapterNumber}`
-            : null,
-        views,
-        date,
-        chapterNumber,
-      });
+  chapterRows.forEach((el) => {
+    const row = $(el);
+    const chapterLinkElement = row.find('a[href*="chapter"]').first();
+    const chapter = parseChapterLink($, chapterLinkElement);
+    const cells = row.find("td");
+    chapters.push({
+      ...chapter,
+      views: normalizeText(row.find(".pembaca, td.pembaca, i").first().text()),
+      date:
+        normalizeText(row.find(".tanggalseries").first().text()) ||
+        normalizeText(cells.last().text()),
     });
+  });
 
-    const similarKomik = [];
-    try {
-      $("section#Spoiler div.grd").each((i, el) => {
-        try {
-          const title = $(el).find("div.h4").text().trim();
-          const link = $(el).find("a").attr("href");
-
-          // Perbaikan untuk menangani gambar lazy loading
-          let thumbnail = $(el).find("img").attr("src") || "";
-
-          // Jika gambar menggunakan lazy loading, ambil dari data-src
-          if (
-            $(el).find("img").hasClass("lazy") ||
-            (thumbnail && thumbnail.includes("lazy.jpg"))
-          ) {
-            thumbnail = $(el).find("img").attr("data-src") || thumbnail;
-          }
-
-          const type = $(el).find("div.tpe1_inf b").text().trim() || "";
-          const genres =
-            $(el).find("div.tpe1_inf").text().replace(type, "").trim() || "";
-          const synopsis = $(el).find("p").text().trim() || "";
-          const views = $(el).find("div.vw").text().trim() || "";
-
-          let similarKomikSlug = "";
-          if (link) {
-            const mangaMatches = link.match(/\/manga\/([^/]+)/);
-            if (mangaMatches && mangaMatches[1]) {
-              similarKomikSlug = mangaMatches[1];
-            }
-          }
-
-          similarKomik.push({
-            title,
-            originalLink: link || "",
-            apiLink: similarKomikSlug
-              ? `/detail-komik/${similarKomikSlug}`
-              : null,
-            thumbnail,
-            type,
-            genres,
-            synopsis,
-            views,
-            slug: similarKomikSlug,
-          });
-        } catch (itemError) {
-          console.error("Error processing similar komik item:", itemError);
-          // Lanjutkan ke item berikutnya
-        }
-      });
-    } catch (sectionError) {
-      console.error("Error processing similar komik section:", sectionError);
-      // Tetap lanjutkan dengan similarKomik kosong
-    }
-
-    return {
-      title,
-      alternativeTitle,
-      description,
-      sinopsis,
-      thumbnail,
-      info: infoTable,
-      genres,
-      slug: komikSlug,
-      firstChapter: {
-        ...firstChapter,
-        originalLink: firstChapterLink?.startsWith("http")
-          ? firstChapterLink
-          : `https://komiku.id${firstChapterLink}`,
-      },
-      latestChapter: {
-        ...latestChapter,
-        originalLink: latestChapterLink?.startsWith("http")
-          ? latestChapterLink
-          : `https://komiku.id${latestChapterLink}`,
-      },
-      chapters: chapters.map((chapter) => ({
-        ...chapter,
-        originalLink: chapter.originalLink?.startsWith("http")
-          ? chapter.originalLink
-          : `https://komiku.id${chapter.originalLink}`,
-      })),
-      similarKomik: similarKomik.map((komik) => ({
-        ...komik,
-        originalLink: komik.originalLink?.startsWith("http")
-          ? komik.originalLink
-          : `https://komiku.id${komik.originalLink}`,
-      })),
-    };
-  } catch (error) {
-    throw error;
+  if (!chapters.length) {
+    $('a[href*="chapter"]').each((_, el) => {
+      const chapter = parseChapterLink($, $(el));
+      if (chapter.originalLink && chapter.title) {
+        chapters.push({ ...chapter, views: "", date: "" });
+      }
+    });
   }
+
+  const similarKomik = [];
+  $("section#Spoiler, section")
+    .filter((_, el) => /Komik Serupa/i.test(normalizeText($(el).text())))
+    .find('a[href*="/manga/"]')
+    .each((_, el) => {
+      const linkElement = $(el);
+      const card = linkElement.closest("article, li, div");
+      const originalLink = getAbsoluteUrl(linkElement.attr("href"));
+      const slug = extractMangaSlug(originalLink);
+      const img = card.find("img").first();
+      const type =
+        normalizeText(card.find("strong, b").first().text()) ||
+        normalizeText(card.find("[itemprop='additionalType']").attr("content"));
+
+      const item = {
+        title:
+          cleanTitle(card.find(".h4, h3, h4").first().text()) ||
+          cleanTitle(linkElement.attr("title")) ||
+          cleanTitle(img.attr("alt")),
+        originalLink,
+        apiLink: slug ? `/detail-komik/${slug}` : null,
+        thumbnail: getImageUrl($, img),
+        type,
+        genres: normalizeText(card.find(".tpe1_inf").text()).replace(type, "").trim(),
+        synopsis: normalizeText(card.find("p").first().text()),
+        views: normalizeText(card.find(".vw").first().text()),
+        slug,
+      };
+
+      if (
+        item.title &&
+        item.originalLink &&
+        !similarKomik.some((komik) => komik.slug === item.slug)
+      ) {
+        similarKomik.push(item);
+      }
+    });
+
+  if (!title || !thumbnail || !chapters.length) {
+    logEmptyParse("GET /detail-komik", data, {
+      target: url,
+      titleFound: !!title,
+      thumbnailFound: !!thumbnail,
+      chaptersFound: chapters.length,
+      selectors:
+        "h1, section#Informasi img, section#Chapter a[href*='chapter']",
+    });
+  }
+
+  return {
+    title,
+    alternativeTitle,
+    description,
+    sinopsis,
+    thumbnail,
+    info: infoTable,
+    genres,
+    slug: komikSlug,
+    firstChapter,
+    latestChapter,
+    chapters,
+    similarKomik,
+  };
 }
 
 const getDetail = async (req, res) => {
   try {
     const { slug } = req.params;
-
-    const komikUrl = `${URL}manga/${slug}/`;
-
+    const komikUrl = `${BASE_URL}/manga/${slug}/`;
     const komikDetail = await scrapeKomikDetail(komikUrl);
+
+    if (!komikDetail.title || !komikDetail.chapters.length) {
+      return res.status(502).json({
+        error: "Gagal parsing detail komik dari Komiku.",
+        detail:
+          "Struktur HTML detail komik kemungkinan berubah atau data chapter kosong.",
+      });
+    }
+
     res.json(komikDetail);
   } catch (err) {
     console.error("Error fetching komik detail:", err);
@@ -247,36 +219,5 @@ const getDetail = async (req, res) => {
     });
   }
 };
-
-router.get("/url", async (req, res) => {
-  try {
-    const { url } = req.query;
-
-    if (!url) {
-      return res.status(400).json({
-        error: "URL parameter diperlukan",
-      });
-    }
-
-    if (
-      !url.startsWith("https://komiku.id/manga/") &&
-      !url.startsWith("http://komiku.id/manga/")
-    ) {
-      return res.status(400).json({
-        error: "URL tidak valid, harus dari komiku.id/manga/",
-      });
-    }
-
-    const komikDetail = await scrapeKomikDetail(url);
-    res.json(komikDetail);
-  } catch (err) {
-    console.error("Error fetching komik detail from URL:", err);
-    res.status(500).json({
-      error: "Gagal mengambil detail komik",
-      detail: err.message,
-      stack: process.env.NODE_ENV === "development" ? err.stack : undefined,
-    });
-  }
-});
 
 module.exports = { getDetail };

--- a/controllers/genreAllController.js
+++ b/controllers/genreAllController.js
@@ -1,63 +1,64 @@
-// File: routes/genre-all.js
-const express = require("express");
-const axios = require("axios");
 const cheerio = require("cheerio");
-const router = express.Router();
-const URL_KOMIKU = "https://komiku.org/";
+const {
+  BASE_URL,
+  fetchHtml,
+  normalizeText,
+  extractMangaSlug,
+  logEmptyParse,
+} = require("./scraperUtils");
+
+function extractGenreSlug(url) {
+  return String(url || "").match(/\/genre\/([^/]+)/)?.[1] || "";
+}
 
 const getGenreAll = async (req, res) => {
   try {
-    const { data } = await axios.get(URL_KOMIKU, {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-        Accept:
-          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.5",
-        "Cache-Control": "public, max-age=3600", // Cache for 1 hour
-      },
-      timeout: 10000, // Optional: 10 seconds timeout
-    });
-
+    const data = await fetchHtml(BASE_URL);
     const $ = cheerio.load(data);
     const allGenres = [];
+    const seen = new Set();
 
-    // Scraping semua genre dari ul.genre
-    $("ul.genre li").each((i, el) => {
-      const anchorTag = $(el).find("a");
+    $("#Filter select[name='genre'] option[value]").each((_, el) => {
+      const option = $(el);
+      const genreSlug = normalizeText(option.attr("value"));
+      const title = normalizeText(option.text()).replace(/\s*\(\d+\)\s*$/, "");
 
-      const title = anchorTag.text().trim();
-      const originalLinkPath = anchorTag.attr("href");
-      const titleAttr = anchorTag.attr("title");
-
-      // Extract genre slug from URL
-      let genreSlug = "";
-      if (originalLinkPath) {
-        const matches = originalLinkPath.match(/\/genre\/([^/]+)/);
-        if (matches && matches[1]) {
-          genreSlug = matches[1];
-        }
-      }
-
-      const apiGenreLink = genreSlug ? `/genre/${genreSlug}` : originalLinkPath;
-
-      // Memastikan originalLink adalah URL absolut
-      const finalOriginalLink = originalLinkPath?.startsWith("http")
-        ? originalLinkPath
-        : originalLinkPath
-        ? `${URL_KOMIKU.slice(0, -1)}${originalLinkPath}`
-        : null;
-
-      if (title && originalLinkPath) {
+      if (title && genreSlug && !seen.has(genreSlug)) {
+        seen.add(genreSlug);
         allGenres.push({
           title,
           slug: genreSlug,
-          // originalLink: finalOriginalLink,
-          apiGenreLink,
-          titleAttr: titleAttr || title,
+          apiGenreLink: `/genre/${genreSlug}`,
+          titleAttr: title,
         });
       }
     });
+
+    $(
+      '#Filter a[href*="/genre/"], #genr a[href*="/genre/"], a[href*="/genre/"]'
+    ).each((_, el) => {
+      const anchorTag = $(el);
+      const title = normalizeText(anchorTag.text()).replace(/\s*\(\d+\)\s*$/, "");
+      const originalLinkPath = anchorTag.attr("href");
+      const genreSlug = extractGenreSlug(originalLinkPath);
+
+      if (title && genreSlug && !extractMangaSlug(originalLinkPath) && !seen.has(genreSlug)) {
+        seen.add(genreSlug);
+        allGenres.push({
+          title,
+          slug: genreSlug,
+          apiGenreLink: `/genre/${genreSlug}`,
+          titleAttr: normalizeText(anchorTag.attr("title")) || title,
+        });
+      }
+    });
+
+    if (!allGenres.length) {
+      logEmptyParse("GET /genre-all", data, {
+        target: BASE_URL,
+        selector: 'a[href*="/genre/"]',
+      });
+    }
 
     res.json(allGenres);
   } catch (err) {

--- a/controllers/genreDetailController.js
+++ b/controllers/genreDetailController.js
@@ -1,35 +1,93 @@
-// File: routes/genre-detail.js
-const express = require("express");
-const axios = require("axios");
 const cheerio = require("cheerio");
-const router = express.Router();
+const {
+  BASE_URL,
+  fetchHtml,
+  getAbsoluteUrl,
+  normalizeText,
+  cleanTitle,
+  getImageUrl,
+  extractMangaSlug,
+  getApiChapterLink,
+  logEmptyParse,
+} = require("./scraperUtils");
 
-const URL_KOMIKU = "https://komiku.org/";
+function parseMangaCard($, el) {
+  const card = $(el);
+  const mangaLinkElement =
+    card.find('h3 a[href*="/manga/"], h2 a[href*="/manga/"], h4 a[href*="/manga/"]').first()
+      .length
+      ? card.find('h3 a[href*="/manga/"], h2 a[href*="/manga/"], h4 a[href*="/manga/"]').first()
+      : card.find('a[href*="/manga/"]').first();
+  const mangaLink = getAbsoluteUrl(mangaLinkElement.attr("href"));
+  const mangaSlug = extractMangaSlug(mangaLink);
+  const img = card.find('a[href*="/manga/"] img, img').first();
+  const type = normalizeText(card.find(".tpe1_inf b, .tpe1_inf strong").first().text());
+  const typeGenreText = normalizeText(card.find(".tpe1_inf").first().text());
+  const chapterElements = card.find('a[href*="chapter"]').toArray();
+  const firstChapterElement = chapterElements.length ? $(chapterElements[0]) : null;
+  const latestChapterElement = chapterElements.length
+    ? $(chapterElements[chapterElements.length - 1])
+    : null;
 
-const URL_LOCAL = "https://mangaverse.my.id/";
-// GET /genre/:slug - Mendapatkan manga berdasarkan genre (halaman 1)
-// router.get("/:slug", async (req, res) => {
-//   req.params.page = "1";
-//   return handleGenreRequest(req, res);
-// });
+  return {
+    title:
+      cleanTitle(card.find("h3, h2, h4").first().text()) ||
+      cleanTitle(mangaLinkElement.attr("title")) ||
+      cleanTitle(img.attr("alt")),
+    slug: mangaSlug,
+    type,
+    genre: typeGenreText.replace(type, "").trim(),
+    thumbnail: getImageUrl($, img),
+    description: normalizeText(card.find("p").first().text()),
+    additionalInfo: normalizeText(card.find(".judul2").first().text()),
+    updateStatus: normalizeText(card.find(".up").first().text()),
+    apiMangaLink: mangaSlug ? `/detail-komik/${mangaSlug}` : null,
+    chapters: {
+      first: firstChapterElement
+        ? {
+            chapter: normalizeText(firstChapterElement.text()) ||
+              normalizeText(firstChapterElement.attr("title")),
+            link: getAbsoluteUrl(firstChapterElement.attr("href")),
+            apiLink: getApiChapterLink(firstChapterElement.attr("href")),
+          }
+        : null,
+      latest: latestChapterElement
+        ? {
+            chapter: normalizeText(latestChapterElement.text()) ||
+              normalizeText(latestChapterElement.attr("title")),
+            link: getAbsoluteUrl(latestChapterElement.attr("href")),
+            apiLink: getApiChapterLink(latestChapterElement.attr("href")),
+          }
+        : null,
+    },
+  };
+}
 
-// // GET /genre/:slug/page/:page - Route untuk pagination yang benar
-// router.get("/:slug/page/:page", async (req, res) => {
-//   return handleGenreRequest(req, res);
-// });
+async function loadGenreHtml(slug, pageNum) {
+  const pagePath = pageNum > 1 ? `/genre/${slug}/page/${pageNum}/` : `/genre/${slug}/`;
+  const targetUrl = `${BASE_URL}${pagePath}`;
+  const shellHtml = await fetchHtml(targetUrl);
+  const $shell = cheerio.load(shellHtml);
+  const htmxUrl = $shell("[hx-get], [data-hx-get]").first().attr("hx-get");
 
-// // GET /genre/:slug/:page - Backward compatibility
-// router.get("/:slug/:page", async (req, res) => {
-//   return handleGenreRequest(req, res);
-// });
+  if (!htmxUrl) {
+    return { html: shellHtml, targetUrl, htmxUrl: null };
+  }
 
-// Function untuk handle request genre
+  const html = await fetchHtml(htmxUrl, {
+    headers: {
+      "HX-Request": "true",
+      Referer: targetUrl,
+    },
+  });
+
+  return { html, targetUrl, htmxUrl: getAbsoluteUrl(htmxUrl) };
+}
+
 async function handleGenreRequest(req, res) {
   try {
     const { slug, page = 1 } = req.params;
-
-    // Validasi page number
-    const pageNum = parseInt(page);
+    const pageNum = parseInt(page, 10);
     if (isNaN(pageNum) || pageNum < 1) {
       return res.status(400).json({
         error: "Invalid page number",
@@ -37,259 +95,36 @@ async function handleGenreRequest(req, res) {
       });
     }
 
-    // Construct URL berdasarkan slug dan page - gunakan API URL
-    const targetUrl = `https://api.komiku.org/genre/${slug}/page/${pageNum}/`;
-
-    console.log(`Fetching: ${targetUrl}`);
-
-    const { data } = await axios.get(targetUrl, {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-        Accept:
-          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.5",
-        "Accept-Encoding": "gzip, deflate, br",
-        "Cache-Control": "no-cache",
-        Referer: "https://komiku.org/",
-        Origin: "https://komiku.org",
-      },
-      timeout: 15000, // 15 seconds timeout
-    });
-
-    const $ = cheerio.load(data);
-    const mangaList = [];
-
-    // Debug: log berapa banyak elemen .bge yang ditemukan
-    console.log(`Found ${$(".bge").length} .bge elements`);
-    console.log("HTML length:", data.length);
-    console.log("Is HTML?", data.includes("<html>"));
-
-    // Log first 500 chars to see what we got
-    console.log("Response preview:", data.substring(0, 500));
-
-    // Coba selector alternatif jika .bge tidak ada
-    let mangaElements = $(".bge");
-    if (mangaElements.length === 0) {
-      // Coba selector alternatif
-      mangaElements = $(".daftar .bge, .list-manga .item, .manga-item, .entry");
-      console.log(
-        `Trying alternative selectors, found ${mangaElements.length} elements`
-      );
-    }
-
-    // Scraping manga dari class "bge" atau selector alternatif
-    mangaElements.each((i, el) => {
-      const $el = $(el);
-
-      // Ambil link manga - coba beberapa selector
-      let mangaLinkElement = $el.find(".kan a").first();
-      if (mangaLinkElement.length === 0) {
-        mangaLinkElement = $el.find("a").first();
-      }
-      const mangaLink = mangaLinkElement.attr("href");
-
-      // Ambil judul manga - coba beberapa selector
-      let title = $el.find(".kan h3").text().trim();
-      if (!title) {
-        title = $el.find("h3, h2, .title, .judul").text().trim();
-      }
-
-      // Ambil thumbnail - coba beberapa selector
-      let thumbnailElement = $el.find(".bgei img");
-      if (thumbnailElement.length === 0) {
-        thumbnailElement = $el.find("img").first();
-      }
-
-      let thumbnail = thumbnailElement.attr("src");
-      if (!thumbnail || thumbnail.trim() === "") {
-        thumbnail =
-          thumbnailElement.attr("data-src") ||
-          thumbnailElement.attr("data-lazy");
-      }
-
-      // Pastikan thumbnail adalah URL absolut
-      if (thumbnail && !thumbnail.startsWith("http")) {
-        thumbnail = thumbnail.startsWith("//")
-          ? `https:${thumbnail}`
-          : `${URL_LOCAL.slice(0, -1)}${thumbnail}`;
-      }
-
-      // Ambil tipe dan genre - parsing yang lebih robust
-      const typeGenreElement = $el.find(".tpe1_inf");
-      const typeGenreText = typeGenreElement.text().trim();
-
-      let type = "";
-      let genre = "";
-
-      // Extract type dari <b> tag
-      const typeElement = typeGenreElement.find("b");
-      if (typeElement.length > 0) {
-        type = typeElement.text().trim();
-        // Genre adalah text setelah <b> tag
-        genre = typeGenreText.replace(type, "").trim();
-      } else {
-        // Fallback ke regex jika tidak ada <b> tag
-        const typeGenreMatch = typeGenreText.match(
-          /^(Manga|Manhwa|Manhua)\s+(.+)$/
-        );
-        if (typeGenreMatch) {
-          type = typeGenreMatch[1];
-          genre = typeGenreMatch[2];
+    const { html, targetUrl, htmxUrl } = await loadGenreHtml(slug, pageNum);
+    const $ = cheerio.load(html);
+    const mangaElements = $('.bge:has(a[href*="/manga/"]), article:has(a[href*="/manga/"])');
+    const seen = new Set();
+    const mangaList = mangaElements
+      .toArray()
+      .map((el) => parseMangaCard($, el))
+      .filter((item) => {
+        if (!item.title || !item.thumbnail || !item.slug || seen.has(item.slug)) {
+          return false;
         }
-      }
+        seen.add(item.slug);
+        return true;
+      });
 
-      // Ambil info tambahan (views, waktu, dll)
-      const additionalInfo = $el.find(".judul2").text().trim();
+    const nextPageElement = $("[hx-get], [data-hx-get]").last();
+    const nextHxUrl = nextPageElement.attr("hx-get");
+    const nextPageMatch = nextHxUrl?.match(/page\/(\d+)/);
+    const hasNextPage = Boolean(nextPageMatch) || mangaList.length >= 10;
+    const nextPageUrl = nextPageMatch
+      ? `/genre/${slug}/page/${parseInt(nextPageMatch[1], 10)}`
+      : mangaList.length >= 10
+      ? `/genre/${slug}/page/${pageNum + 1}`
+      : null;
 
-      // Ambil deskripsi
-      const description = $el.find(".kan p").text().trim();
-
-      // Ambil chapter pertama dan terakhir
-      const chapterElements = $el.find(".new1 a");
-      let firstChapter = "";
-      let latestChapter = "";
-      let firstChapterLink = "";
-      let latestChapterLink = "";
-
-      if (chapterElements.length >= 1) {
-        const firstChapterElement = $(chapterElements[0]);
-        firstChapter = firstChapterElement.find("span").last().text().trim();
-        firstChapterLink = firstChapterElement.attr("href");
-      }
-
-      if (chapterElements.length >= 2) {
-        const latestChapterElement = $(chapterElements[1]);
-        latestChapter = latestChapterElement.find("span").last().text().trim();
-        latestChapterLink = latestChapterElement.attr("href");
-      }
-
-      // Ambil update status
-      const updateStatus = $el.find(".up").text().trim();
-
-      // Extract manga slug dari link
-      let mangaSlug = "";
-      if (mangaLink) {
-        const slugMatch = mangaLink.match(/\/manga\/([^/]+)/);
-        if (slugMatch && slugMatch[1]) {
-          mangaSlug = slugMatch[1];
-        }
-      }
-
-      // Ensure all links are absolute URLs
-      const absoluteMangaLink = mangaLink?.startsWith("http")
-        ? mangaLink
-        : mangaLink
-        ? `${URL_KOMIKU.slice(0, -1)}${mangaLink}`
-        : null;
-
-      const absoluteFirstChapterLink = firstChapterLink?.startsWith("http")
-        ? firstChapterLink
-        : firstChapterLink
-        ? `${URL_KOMIKU.slice(0, -1)}${firstChapterLink}`
-        : null;
-
-      const absoluteLatestChapterLink = latestChapterLink?.startsWith("http")
-        ? latestChapterLink
-        : latestChapterLink
-        ? `${URL_LOCAL.slice(0, -1)}${latestChapterLink}`
-        : null;
-
-      // Debug: log data yang ditemukan
-      if (i < 3) {
-        // Log hanya 3 item pertama untuk debug
-        console.log(`Item ${i}:`, {
-          title,
-          thumbnail,
-          mangaLink,
-          hasRequiredData: !!(title && thumbnail),
-        });
-      }
-
-      // Hanya tambahkan jika ada data penting
-      if (title && thumbnail) {
-        mangaList.push({
-          title,
-          slug: mangaSlug,
-          type,
-          genre,
-          thumbnail,
-          description,
-          additionalInfo,
-          updateStatus,
-          // mangaLink: absoluteMangaLink,
-          apiMangaLink: mangaSlug ? `/detail-komik/${mangaSlug}` : null,
-          chapters: {
-            first: {
-              chapter: firstChapter,
-              link: absoluteFirstChapterLink,
-              apiLink: firstChapterLink ? `/chapter${firstChapterLink}` : null,
-            },
-            latest: {
-              chapter: latestChapter,
-              link: absoluteLatestChapterLink,
-              apiLink:
-                mangaSlug && latestChapter
-                  ? `/baca-chapter/${mangaSlug}/${latestChapter.replace(
-                      /[^0-9]/g,
-                      ""
-                    )}`
-                  : null,
-            },
-          },
-        });
-      }
-    });
-
-    // Cek apakah ada pagination/loading indicator untuk halaman selanjutnya
-    const hasNextPage =
-      $("#hxloading").length > 0 ||
-      $("span[hx-get]").length > 0 ||
-      $(".pagination .next").length > 0 ||
-      $(".next-page").length > 0;
-
-    // Extract next page URL jika ada
-    let nextPageUrl = null;
-    const nextPageElement = $("span[hx-get]");
-    if (nextPageElement.length > 0) {
-      const hxGetUrl = nextPageElement.attr("hx-get");
-      if (hxGetUrl) {
-        console.log("Found hx-get URL:", hxGetUrl);
-        const nextPageMatch = hxGetUrl.match(/page\/(\d+)/);
-        if (nextPageMatch && nextPageMatch[1]) {
-          const nextPageNum = parseInt(nextPageMatch[1]);
-          nextPageUrl = `/genre/${slug}/page/${nextPageNum}`;
-        }
-      }
-    } else {
-      // Fallback: jika ada manga, assume ada next page (kecuali jumlah manga < expected)
-      if (mangaList.length >= 10) {
-        // Assuming 10+ manga per page means there might be more
-        nextPageUrl = `/genre/${slug}/page/${pageNum + 1}`;
-      }
-    }
-
-    // Response data
-    const responseData = {
-      success: true,
-      genre: slug,
-      currentPage: pageNum,
-      totalManga: mangaList.length,
-      hasNextPage,
-      nextPageUrl,
-      data: mangaList,
-      debug: {
-        targetUrl,
-        elementsFound: mangaElements.length,
-        pageTitle: $("title").text().trim(),
-      },
-    };
-
-    // Jika tidak ada manga ditemukan
-    if (mangaList.length === 0) {
-      // Tambahan debug info
-      const pageContent = $.html().substring(0, 500);
-      console.log("Page content preview:", pageContent);
+    if (!mangaList.length) {
+      logEmptyParse("GET /genre", html, {
+        target: htmxUrl || targetUrl,
+        selector: '.bge/article + a[href*="/manga/"]',
+      });
 
       return res.status(404).json({
         success: false,
@@ -299,41 +134,32 @@ async function handleGenreRequest(req, res) {
         currentPage: pageNum,
         debug: {
           targetUrl,
-          pageTitle: $("title").text().trim(),
+          htmxUrl,
           elementsFound: mangaElements.length,
-          possibleSelectors: [
-            `.bge: ${$(".bge").length}`,
-            `.daftar .bge: ${$(".daftar .bge").length}`,
-            `.list-manga .item: ${$(".list-manga .item").length}`,
-            `.manga-item: ${$(".manga-item").length}`,
-            `.entry: ${$(".entry").length}`,
-          ],
         },
       });
     }
 
-    res.json(responseData);
+    res.json({
+      success: true,
+      genre: slug,
+      currentPage: pageNum,
+      totalManga: mangaList.length,
+      hasNextPage,
+      nextPageUrl,
+      data: mangaList,
+      debug: {
+        targetUrl,
+        htmxUrl,
+        elementsFound: mangaElements.length,
+        pageTitle: $("title").text().trim(),
+      },
+    });
   } catch (err) {
     console.error(
       `Error on GET /genre/${req.params.slug}/${req.params.page || 1}:`,
       err.message
     );
-
-    // Handle specific error types
-    if (err.response) {
-      // Server responded with error status
-      const statusCode = err.response.status;
-      if (statusCode === 404) {
-        return res.status(404).json({
-          success: false,
-          error: "Genre or page not found",
-          message: `Genre "${req.params.slug}" or page ${
-            req.params.page || 1
-          } not found`,
-          statusCode,
-        });
-      }
-    }
 
     res.status(500).json({
       success: false,
@@ -345,4 +171,5 @@ async function handleGenreRequest(req, res) {
     });
   }
 }
+
 module.exports = { handleGenreRequest };

--- a/controllers/genreRekomendasiController.js
+++ b/controllers/genreRekomendasiController.js
@@ -1,42 +1,42 @@
 // File: routes/genre.js
-const express = require("express");
-const axios = require("axios");
 const cheerio = require("cheerio");
-const router = express.Router();
-const URL_KOMIKU = "https://komiku.org/";
+const {
+  BASE_URL,
+  fetchHtml,
+  getAbsoluteUrl,
+  normalizeText,
+  getImageUrl,
+  logEmptyParse,
+} = require("./scraperUtils");
 
 const genreRekomendasi = async (req, res) => {
   try {
-    const { data } = await axios.get(URL_KOMIKU, {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-        Accept:
-          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.5",
-        "Cache-Control": "public, max-age=3600", // Cache for 1 hour
-      },
-      timeout: 10000, // Optional: 10 seconds timeout
-    });
+    const data = await fetchHtml(BASE_URL);
 
     const $ = cheerio.load(data);
     const genreRekomendasi = [];
 
-    // Scraping bagian rekomendasi genre dengan gambar (ls3)
-    $(".ls3").each((i, el) => {
+    const genreCards = $(".ls3").length
+      ? $(".ls3")
+      : $('a[href*="/other/"], a[href*="/statusmanga/"]')
+          .closest("article, li, div")
+          .filter((_, el) => $(el).find("img").length > 0);
+
+    genreCards.each((i, el) => {
+      if (!$(el).find('a[href*="/genre/"], a[href*="/other/"], a[href*="/statusmanga/"]').length) return;
       const anchorTag = $(el).find("a").first();
       const imgTag = $(el).find("img");
-      const titleElement = $(el).find(".ls3p h4");
-      const readLinkElement = $(el).find(".ls3p a");
+      const titleElement = $(el).find("h4, h3").first();
+      const readLinkElement =
+        $(el).find('a[href*="/genre/"], a[href*="/other/"], a[href*="/statusmanga/"]').last();
 
-      const title = titleElement.text().trim();
+      const title =
+        normalizeText(titleElement.text()) ||
+        normalizeText(anchorTag.attr("title")) ||
+        normalizeText(imgTag.attr("alt"));
       const originalLinkPath = anchorTag.attr("href");
       const readLinkPath = readLinkElement.attr("href");
-
-      let thumbnail = imgTag.attr("src");
-      if (!thumbnail || thumbnail.trim() === "") {
-        thumbnail = imgTag.attr("data-src");
-      }
+      const thumbnail = getImageUrl($, imgTag);
 
       // Extract genre slug from URL
       let genreSlug = "";
@@ -58,20 +58,15 @@ const genreRekomendasi = async (req, res) => {
       const apiGenreLink = genreSlug ? `/genre/${genreSlug}` : originalLinkPath;
 
       // Memastikan originalLink adalah URL absolut
-      const finalOriginalLink = originalLinkPath?.startsWith("http")
-        ? originalLinkPath
-        : originalLinkPath
-        ? `${URL_KOMIKU.slice(0, -1)}${originalLinkPath}`
-        : null;
+      const finalOriginalLink = getAbsoluteUrl(originalLinkPath);
 
-      // Memastikan readLink adalah URL absolut
-      const finalReadLink = readLinkPath?.startsWith("http")
-        ? readLinkPath
-        : readLinkPath
-        ? `${URL_KOMIKU.slice(0, -1)}${readLinkPath}`
-        : null;
+      const finalReadLink = getAbsoluteUrl(readLinkPath);
 
-      if (title && thumbnail) {
+      if (
+        title &&
+        thumbnail &&
+        !genreRekomendasi.some((item) => item.originalLink === finalOriginalLink)
+      ) {
         genreRekomendasi.push({
           title,
           slug: genreSlug,
@@ -82,6 +77,13 @@ const genreRekomendasi = async (req, res) => {
         });
       }
     });
+
+    if (!genreRekomendasi.length) {
+      logEmptyParse("GET /genre-rekomendasi", data, {
+        target: BASE_URL,
+        selector: '.ls3, a[href*="/genre/"], img',
+      });
+    }
 
     res.json(genreRekomendasi);
   } catch (err) {

--- a/controllers/komikPopulerController.js
+++ b/controllers/komikPopulerController.js
@@ -1,145 +1,126 @@
-const express = require("express");
-const axios = require("axios");
 const cheerio = require("cheerio");
-const router = express.Router();
+const {
+  BASE_URL,
+  fetchHtml,
+  getAbsoluteUrl,
+  normalizeText,
+  cleanTitle,
+  getImageUrl,
+  extractMangaSlug,
+  extractChapterNumber,
+  getApiChapterLink,
+  logEmptyParse,
+} = require("./scraperUtils");
 
-const URL_KOMIKU = "https://komiku.org/";
-
-/**
- * @param {cheerio.CheerioAPI} $
- * @param {string} sectionSelector
- * @returns {{title: string, items: Array<object>}}
- */
-function scrapeKomikSection($, sectionSelector) {
-  const sectionElement = $(sectionSelector);
-  const resultItems = [];
-
-  const sectionTitle = sectionElement.find("h2.lsh3").text().trim();
-
-  sectionElement.find("article.ls2").each((i, el) => {
-    const articleElement = $(el);
-    const linkElement = articleElement.find(".ls2v > a").first();
-    const imgElement = linkElement.find("img");
-    const detailElement = articleElement.find(".ls2j");
-
-    let title = imgElement
-      .attr("alt")
-      ?.replace(/^Baca (Manga|Manhwa|Manhua|Komik)\s+/i, "")
-      .trim();
-    if (!title) {
-      title = detailElement.find("h3 a").text().trim();
-    }
-
-    const originalLinkPath = linkElement.attr("href");
-    const originalLink = originalLinkPath?.startsWith("http")
-      ? originalLinkPath
-      : originalLinkPath
-      ? `${URL_KOMIKU.slice(0, -1)}${originalLinkPath}`
-      : null;
-
-    let thumbnail = imgElement.attr("data-src");
-    if (!thumbnail || thumbnail.trim() === "") {
-      thumbnail = imgElement.attr("src");
-    }
-    // Opsional: Hapus query params jika tidak diinginkan, contoh: ?resize=
-    // if (thumbnail && thumbnail.includes('?resize=')) {
-    //   thumbnail = thumbnail.split('?resize=')[0];
-    // }
-
-    const infoText = detailElement.find(".ls2t").text().trim(); // e.g., "Fantasi 1.3jt pembaca"
-    let genre = "";
-    let readers = "";
-
-    const pembacaMatch = infoText.match(
-      /(.+?)\s+([\d.,]+[mjkrb龕万KMBT]?\s*pembaca)$/i
-    );
-    if (pembacaMatch) {
-      genre = pembacaMatch[1].trim();
-      readers = pembacaMatch[2].trim();
-    } else {
-      genre = infoText;
-    }
-
-    const latestChapterElement = detailElement.find("a.ls2l");
-    const latestChapter = latestChapterElement.text().trim();
-    const chapterLinkPath = latestChapterElement.attr("href");
-    const originalChapterLink = chapterLinkPath?.startsWith("http")
-      ? chapterLinkPath
-      : chapterLinkPath
-      ? `${URL_KOMIKU.slice(0, -1)}${chapterLinkPath}`
-      : null;
-
-    let mangaSlug = "";
-    if (originalLinkPath) {
-      const mangaMatches = originalLinkPath.match(/\/manga\/([^/]+)/);
-      if (mangaMatches && mangaMatches[1]) {
-        mangaSlug = mangaMatches[1];
-      }
-    }
-
-    let chapterNumber = "";
-    if (chapterLinkPath) {
-      const chapterNumMatch =
-        chapterLinkPath.match(/-chapter-([\d.]+)\/?$/i) ||
-        chapterLinkPath.match(/\/chapter[_-]([\d.]+)\/?$/i) ||
-        chapterLinkPath.match(/\/([\d.]+)\/?$/i);
-      if (chapterNumMatch && chapterNumMatch[1]) {
-        chapterNumber = chapterNumMatch[1];
-      } else {
-        const textMatch = latestChapter.match(/Chapter\s*([\d.]+)/i);
-        if (textMatch && textMatch[1]) {
-          chapterNumber = textMatch[1];
-        }
-      }
-    }
-
-    const apiDetailLink = mangaSlug ? `/detail-komik/${mangaSlug}` : null;
-    const apiChapterLink =
-      mangaSlug && chapterNumber
-        ? `/baca-chapter/${mangaSlug}/${chapterNumber}`
-        : null;
-
-    if (title && thumbnail && originalLink) {
-      resultItems.push({
-        title,
-        originalLink,
-        apiDetailLink,
-        thumbnail,
-        genre,
-        readers, // e.g., "1.3jt pembaca"
-        latestChapter,
-        originalChapterLink,
-        apiChapterLink,
-        mangaSlug,
-        chapterNumber,
-      });
-    }
-  });
-
-  return { title: sectionTitle, items: resultItems };
+function parseType(...values) {
+  const text = values.map(normalizeText).join(" ");
+  const match = text.match(/\b(Manga|Manhwa|Manhua)\b/i);
+  if (!match) return "";
+  const type = match[1].toLowerCase();
+  return type.charAt(0).toUpperCase() + type.slice(1);
 }
 
-// Route utama untuk mengambil semua data populer (Manga, Manhwa, Manhua)
+function parseKomikCard($, el) {
+  const card = $(el);
+  const mangaLinkElement =
+    card.find('h3 a[href*="/manga/"], h4 a[href*="/manga/"]').first().length
+      ? card.find('h3 a[href*="/manga/"], h4 a[href*="/manga/"]').first()
+      : card.find('a[href*="/manga/"]').first();
+  const originalLink = getAbsoluteUrl(mangaLinkElement.attr("href"));
+  const mangaSlug = extractMangaSlug(originalLink);
+  const img = card.find('a[href*="/manga/"] img, img').first();
+  const infoText = normalizeText(
+    card.find("span, p, small").filter((_, node) => /views?|pembaca|·/i.test($(node).text())).first().text()
+  );
+  const infoParts = infoText.split(/\s*[·|]\s*/).map(normalizeText).filter(Boolean);
+  const genre = infoParts.find((part) => !/views?|pembaca/i.test(part)) || "";
+  const readers = infoParts.find((part) => /views?|pembaca/i.test(part)) || "";
+  const latestChapterElement = card.find('a[href*="chapter"]').last();
+  const originalChapterLink = getAbsoluteUrl(latestChapterElement.attr("href"));
+  const latestChapter =
+    normalizeText(latestChapterElement.text()) ||
+    normalizeText(latestChapterElement.attr("title"));
+  const chapterNumber =
+    extractChapterNumber(originalChapterLink) ||
+    latestChapter.match(/Chapter\s*([\d.]+)/i)?.[1] ||
+    "";
+
+  return {
+    title:
+      cleanTitle(mangaLinkElement.text()) ||
+      cleanTitle(mangaLinkElement.attr("title")) ||
+      cleanTitle(img.attr("alt")),
+    originalLink,
+    apiDetailLink: mangaSlug ? `/detail-komik/${mangaSlug}` : null,
+    thumbnail: getImageUrl($, img),
+    genre,
+    readers,
+    latestChapter,
+    originalChapterLink,
+    apiChapterLink: getApiChapterLink(originalChapterLink, mangaSlug),
+    mangaSlug,
+    chapterNumber,
+    type: parseType(mangaLinkElement.attr("title"), img.attr("alt"), card.text()),
+  };
+}
+
+function scrapeKomikSection($, sectionSelector, fallbackTitle, typeFilter = "") {
+  const sectionElement = $(sectionSelector).length
+    ? $(sectionSelector)
+    : $("section")
+        .filter((_, el) => /Komik Populer|Populer Update|Peringkat/i.test($(el).text()))
+        .first();
+  const title =
+    normalizeText(sectionElement.find("h1,h2,h3").first().text()) ||
+    fallbackTitle;
+  const seen = new Set();
+  const cardElements = sectionElement.find('article:has(a[href*="/manga/"])').length
+    ? sectionElement.find('article:has(a[href*="/manga/"])')
+    : sectionElement.find('li:has(a[href*="/manga/"]), div:has(> a[href*="/manga/"])');
+  const items = cardElements
+    .toArray()
+    .map((el) => parseKomikCard($, el))
+    .filter((item) => {
+      if (
+        !item.title ||
+        !item.originalLink ||
+        !item.thumbnail ||
+        seen.has(item.mangaSlug)
+      ) {
+        return false;
+      }
+
+      if (typeFilter && item.type !== typeFilter) return false;
+      seen.add(item.mangaSlug);
+      return true;
+    })
+    .map(({ type, ...item }) => item);
+
+  return { title: fallbackTitle || title, items };
+}
+
+async function loadHomepage() {
+  const data = await fetchHtml(BASE_URL);
+  return { data, $: cheerio.load(data) };
+}
+
+function ensureItems(context, data, result) {
+  if (!result.items.length) {
+    logEmptyParse(context, data, {
+      target: BASE_URL,
+      selector: '#Komik_Populer a[href*="/manga/"], a[href*="chapter"], img',
+    });
+  }
+}
+
 const komikPopuler = async (req, res) => {
   try {
-    const { data } = await axios.get(URL_KOMIKU, {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-        Accept:
-          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.5",
-        Referer: "https://komiku.id/",
-        "Cache-Control": "public, max-age=3600", // Cache for 1 hour
-        timeout: 10000, // Optional: 10 seconds timeout
-      },
-    });
+    const { data, $ } = await loadHomepage();
+    const mangaPopuler = scrapeKomikSection($, "#Komik_Populer", "Manga Populer", "Manga");
+    const manhwaPopuler = scrapeKomikSection($, "#Komik_Populer", "Manhwa Populer", "Manhwa");
+    const manhuaPopuler = scrapeKomikSection($, "#Komik_Populer", "Manhua Populer", "Manhua");
 
-    const $ = cheerio.load(data);
-
-    const mangaPopuler = scrapeKomikSection($, "#Komik_Hot_Manga");
-    const manhwaPopuler = scrapeKomikSection($, "#Komik_Hot_Manhwa");
-    const manhuaPopuler = scrapeKomikSection($, "#Komik_Hot_Manhua");
+    ensureItems("GET /komik-populer manga", data, mangaPopuler);
 
     res.json({
       manga: mangaPopuler,
@@ -155,16 +136,11 @@ const komikPopuler = async (req, res) => {
   }
 };
 
-// Route spesifik untuk Manga Populer
 const rekomendasiManga = async (req, res) => {
   try {
-    const { data } = await axios.get(URL_KOMIKU, {
-      headers: {
-        // header
-      },
-    });
-    const $ = cheerio.load(data);
-    const mangaPopuler = scrapeKomikSection($, "#Komik_Hot_Manga");
+    const { data, $ } = await loadHomepage();
+    const mangaPopuler = scrapeKomikSection($, "#Komik_Populer", "Manga Populer", "Manga");
+    ensureItems("GET /komik-populer/manga", data, mangaPopuler);
     res.json(mangaPopuler);
   } catch (err) {
     console.error("Error scraping manga populer:", err);
@@ -175,14 +151,11 @@ const rekomendasiManga = async (req, res) => {
   }
 };
 
-// Route spesifik untuk Manhwa Populer
 const rekomendasiManhwa = async (req, res) => {
   try {
-    const { data } = await axios.get(URL_KOMIKU, {
-      headers: {},
-    });
-    const $ = cheerio.load(data);
-    const manhwaPopuler = scrapeKomikSection($, "#Komik_Hot_Manhwa");
+    const { data, $ } = await loadHomepage();
+    const manhwaPopuler = scrapeKomikSection($, "#Komik_Populer", "Manhwa Populer", "Manhwa");
+    ensureItems("GET /komik-populer/manhwa", data, manhwaPopuler);
     res.json(manhwaPopuler);
   } catch (err) {
     console.error("Error scraping manhwa populer:", err);
@@ -193,14 +166,11 @@ const rekomendasiManhwa = async (req, res) => {
   }
 };
 
-// Route spesifik untuk Manhua Populer
 const rekomendasiManhua = async (req, res) => {
   try {
-    const { data } = await axios.get(URL_KOMIKU, {
-      headers: {},
-    });
-    const $ = cheerio.load(data);
-    const manhuaPopuler = scrapeKomikSection($, "#Komik_Hot_Manhua");
+    const { data, $ } = await loadHomepage();
+    const manhuaPopuler = scrapeKomikSection($, "#Komik_Populer", "Manhua Populer", "Manhua");
+    ensureItems("GET /komik-populer/manhua", data, manhuaPopuler);
     res.json(manhuaPopuler);
   } catch (err) {
     console.error("Error scraping manhua populer:", err);

--- a/controllers/pustakaController.js
+++ b/controllers/pustakaController.js
@@ -1,146 +1,137 @@
-const express = require("express");
-const router = express.Router();
-const axios = require("axios");
 const cheerio = require("cheerio");
+const {
+  BASE_URL,
+  fetchHtml,
+  getAbsoluteUrl,
+  normalizeText,
+  cleanTitle,
+  getImageUrl,
+  extractMangaSlug,
+  getApiChapterLink,
+  logEmptyParse,
+} = require("./scraperUtils");
 
-// Function to get random delay between 1-3 seconds
-const getRandomDelay = () =>
-  Math.floor(Math.random() * (3000 - 1000 + 1) + 1000);
+async function getFragmentHtml(pageUrl, selectorContext) {
+  const shellHtml = await fetchHtml(pageUrl);
+  const $ = cheerio.load(shellHtml);
+  const htmxUrl = $("[hx-get], [data-hx-get]").first().attr("hx-get");
 
-// Function to get random user agent
-const getRandomUserAgent = () => {
-  const userAgents = [
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0",
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Safari/605.1.15",
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.59",
-  ];
-  return userAgents[Math.floor(Math.random() * userAgents.length)];
-};
-
-// Function to extract slug from URL
-const extractSlug = (url) => {
-  const matches = url.match(/\/manga\/(.*?)\//);
-  return matches ? matches[1] : "";
-};
-
-// Add this helper function after the extractSlug function
-const formatChapterUrl = (url) => {
-  // Extract the manga title and chapter number
-  const match = url.match(/\/([^/]+)-chapter-(\d+)/);
-  if (match) {
-    const [, title, chapter] = match;
-    return `/baca-chapter/${title}/${chapter}`;
-  }
-  return url;
-};
-
-// Function to scrape manga data from a given page
-async function scrapeMangaData(page = 1) {
-  try {
-    // Add delay before request
-    await new Promise((resolve) => setTimeout(resolve, getRandomDelay()));
-
-    const response = await axios.get(
-      `https://api.komiku.id/manga/page/${page}/`,
-      {
-        headers: {
-          "User-Agent": getRandomUserAgent(),
-          Accept:
-            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-          "Accept-Language": "en-US,en;q=0.5",
-          "Accept-Encoding": "gzip, deflate, br",
-          Connection: "keep-alive",
-          "Upgrade-Insecure-Requests": "1",
-          "Cache-Control": "max-age=0",
-          Referer: "https://komiku.id/",
-        },
-        timeout: 5000,
-      }
-    );
-
-    const $ = cheerio.load(response.data);
-    const mangaList = [];
-
-    $(".bge").each((i, element) => {
-      const url = $(element).find(".bgei a").attr("href");
-      const slug = extractSlug(url);
-
-      // Get first and last chapter elements using more specific selectors
-      const firstChapterElement = $(element).find(
-        ".new1 a[title*='Chapter']:first"
-      );
-      const lastChapterElement = $(element).find(
-        ".new1 a[title*='Chapter']:last"
-      );
-
-      const manga = {
-        title: $(element).find(".kan h3").text().trim(),
-        thumbnail: $(element).find(".bgei img").attr("src"),
-        type: $(element).find(".tpe1_inf b").text(),
-        genre: $(element)
-          .find(".tpe1_inf")
-          .text()
-          .replace($(element).find(".tpe1_inf b").text(), "")
-          .trim(),
-        url: url,
-        detailUrl: `/detail-komik/${slug}`,
-        description: $(element).find(".kan p").text().trim(),
-        stats: $(element).find(".judul2").text().trim(),
-        firstChapter: firstChapterElement.length
-          ? {
-              title: firstChapterElement.attr("title"),
-              url: formatChapterUrl(firstChapterElement.attr("href")),
-            }
-          : null,
-        latestChapter: lastChapterElement.length
-          ? {
-              title: lastChapterElement.attr("title"),
-              url: formatChapterUrl(lastChapterElement.attr("href")),
-            }
-          : null,
-      };
-      mangaList.push(manga);
+  if (!htmxUrl) {
+    logEmptyParse(selectorContext, shellHtml, {
+      target: pageUrl,
+      selector: "[hx-get], [data-hx-get]",
     });
-
-    return {
-      page: page,
-      results: mangaList,
-    };
-  } catch (error) {
-    console.error("Error scraping manga:", error);
-    throw error;
+    return shellHtml;
   }
+
+  return fetchHtml(htmxUrl, {
+    headers: {
+      "HX-Request": "true",
+      Referer: pageUrl,
+    },
+  });
 }
 
-// Add rate limiting middleware
-const rateLimit = require("express-rate-limit");
-const limiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100, // limit each IP to 100 requests per windowMs
-});
+function formatMangaCard($, el) {
+  const card = $(el);
+  const mangaLinkElement =
+    card.find('h1 a[href*="/manga/"], h2 a[href*="/manga/"], h3 a[href*="/manga/"], h4 a[href*="/manga/"]').first()
+      .length
+      ? card.find('h1 a[href*="/manga/"], h2 a[href*="/manga/"], h3 a[href*="/manga/"], h4 a[href*="/manga/"]').first()
+      : card.find('a[href*="/manga/"]').first();
+  const url = getAbsoluteUrl(mangaLinkElement.attr("href"));
+  const slug = extractMangaSlug(url);
+  const img = card.find('a[href*="/manga/"] img, img').first();
+  const type = normalizeText(card.find(".tpe1_inf b, .tpe1_inf strong").first().text());
+  const typeGenreText = normalizeText(card.find(".tpe1_inf").first().text());
+  const chapterLinks = card.find('a[href*="chapter"]').toArray();
+  const firstChapterElement = chapterLinks.length ? $(chapterLinks[0]) : null;
+  const latestChapterElement = chapterLinks.length
+    ? $(chapterLinks[chapterLinks.length - 1])
+    : null;
 
-// Apply rate limiting to all routes
-router.use(limiter);
+  return {
+    title:
+      cleanTitle(card.find("h3, h2, h4").first().text()) ||
+      cleanTitle(mangaLinkElement.attr("title")) ||
+      cleanTitle(img.attr("alt")),
+    thumbnail: getImageUrl($, img),
+    type,
+    genre: typeGenreText.replace(type, "").trim(),
+    url,
+    detailUrl: slug ? `/detail-komik/${slug}` : null,
+    description: normalizeText(card.find("p").first().text()),
+    stats: normalizeText(card.find(".judul2").first().text()),
+    firstChapter: firstChapterElement
+      ? {
+          title:
+            normalizeText(firstChapterElement.attr("title")) ||
+            normalizeText(firstChapterElement.text()),
+          url: getApiChapterLink(firstChapterElement.attr("href")),
+        }
+      : null,
+    latestChapter: latestChapterElement
+      ? {
+          title:
+            normalizeText(latestChapterElement.attr("title")) ||
+            normalizeText(latestChapterElement.text()),
+          url: getApiChapterLink(latestChapterElement.attr("href")),
+        }
+      : null,
+  };
+}
 
-// Route for base pustaka endpoint
+function parseMangaList(html, context) {
+  const $ = cheerio.load(html);
+  const elements = $('.bge:has(a[href*="/manga/"]), article:has(a[href*="/manga/"])').toArray();
+  const seen = new Set();
+  const results = elements
+    .map((el) => formatMangaCard($, el))
+    .filter((item) => {
+      const slug = extractMangaSlug(item.url);
+      if (!item.title || !item.url || seen.has(slug)) return false;
+      seen.add(slug);
+      return true;
+    });
+
+  if (!results.length) {
+    logEmptyParse(context, html, {
+      selector: '.bge/article + a[href*="/manga/"]',
+    });
+  }
+
+  return results;
+}
+
+async function scrapeMangaData(page = 1) {
+  const validPage = Math.max(1, parseInt(page, 10) || 1);
+  const pageUrl = `${BASE_URL}/pustaka/page/${validPage}/`;
+  const html = await getFragmentHtml(pageUrl, `GET /pustaka/page/${validPage}`);
+
+  return {
+    page: validPage,
+    results: parseMangaList(html, `GET /pustaka/page/${validPage}`),
+  };
+}
+
 const getPustaka = {
   getPustakapage: async (req, res) => {
     try {
       const data = await scrapeMangaData(1);
       res.json(data);
     } catch (error) {
+      console.error("Error GET /pustaka:", error);
       res.status(500).json({ error: "Failed to fetch manga data" });
     }
   },
 
-  // Route for paginated pustaka endpoint
   getPustakaPagination: async (req, res) => {
     try {
-      const page = parseInt(req.params.page) || 1;
+      const page = parseInt(req.params.page, 10) || 1;
       const data = await scrapeMangaData(page);
       res.json(data);
     } catch (error) {
+      console.error("Error GET /pustaka/page:", error);
       res.status(500).json({ error: "Failed to fetch manga data" });
     }
   },

--- a/controllers/rekomendasiController.js
+++ b/controllers/rekomendasiController.js
@@ -1,78 +1,66 @@
-// File: routes/rekomendasi.js (atau nama file yang Anda gunakan untuk route ini)
-
-const express = require("express");
-const axios = require("axios");
 const cheerio = require("cheerio");
-const router = express.Router();
-
-const URL_KOMIKU = "https://komiku.org/";
+const {
+  BASE_URL,
+  fetchHtml,
+  getAbsoluteUrl,
+  normalizeText,
+  cleanTitle,
+  getImageUrl,
+  extractMangaSlug,
+  logEmptyParse,
+} = require("./scraperUtils");
 
 const getRekomendasi = async (req, res) => {
   try {
-    const { data } = await axios.get(URL_KOMIKU, {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-        Accept:
-          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.5",
-        "Cache-Control": "public, max-age=3600", // Cache for 1 hour
-      },
-      timeout: 10000, // Optional: 10 seconds timeout
-    });
-
+    const data = await fetchHtml(BASE_URL);
     const $ = cheerio.load(data);
+    const section =
+      $("#Rekomendasi_Komik").length > 0
+        ? $("#Rekomendasi_Komik")
+        : $("section")
+            .filter((_, el) => /Peringkat|Rekomendasi/i.test($(el).text()))
+            .first();
     const rekomendasi = [];
+    const seen = new Set();
 
-    $("#Rekomendasi_Komik article.ls2").each((i, el) => {
-      const anchorTag = $(el).find("a").first();
-      const imgTag = $(el).find("img");
+    section
+      .find('article, li, div:has(a[href*="/manga/"])')
+      .toArray()
+      .forEach((el) => {
+        const card = $(el);
+        const anchorTag =
+          card.find('h3 a[href*="/manga/"], h4 a[href*="/manga/"]').first()
+            .length
+            ? card.find('h3 a[href*="/manga/"], h4 a[href*="/manga/"]').first()
+            : card.find('a[href*="/manga/"]').first();
+        const originalLink = getAbsoluteUrl(anchorTag.attr("href"));
+        const slug = extractMangaSlug(originalLink);
+        if (!slug || seen.has(slug)) return;
 
-      const title = (
-        imgTag.attr("alt") ||
-        anchorTag.attr("alt") ||
-        $(el).find(".ls2j h3 a").text()
-      ) // Fallback ke teks di dalam <h3><a>
-        ?.replace(/^Baca (Komik|Manga|Manhwa|Manhua)\s+/i, "")
-        .trim();
+        const imgTag = card.find('a[href*="/manga/"] img, img').first();
+        const title =
+          cleanTitle(anchorTag.text()) ||
+          cleanTitle(anchorTag.attr("title")) ||
+          cleanTitle(imgTag.attr("alt"));
+        const thumbnail = getImageUrl($, imgTag);
 
-      const originalLinkPath = anchorTag.attr("href");
-
-      let thumbnail = imgTag.attr("data-src");
-      if (!thumbnail || thumbnail.trim() === "") {
-        thumbnail = imgTag.attr("src");
-      }
-
-      // if (thumbnail && thumbnail.includes('?')) {
-      //   thumbnail = thumbnail.split('?')[0];
-      // }
-
-      let slug = "";
-      if (originalLinkPath) {
-        const matches = originalLinkPath.match(/\/manga\/([^/]+)/);
-        if (matches && matches[1]) {
-          slug = matches[1];
+        if (title && thumbnail && originalLink) {
+          seen.add(slug);
+          rekomendasi.push({
+            title,
+            originalLink,
+            apiDetailLink: `/detail-komik/${slug}`,
+            thumbnail,
+          });
         }
-      }
+      });
 
-      const apiDetailLink = slug ? `/detail-komik/${slug}` : originalLinkPath;
-
-      // Memastikan originalLink adalah URL absolut
-      const finalOriginalLink = originalLinkPath?.startsWith("http")
-        ? originalLinkPath
-        : originalLinkPath
-        ? `${URL_KOMIKU.slice(0, -1)}${originalLinkPath}`
-        : null;
-
-      if (title && thumbnail) {
-        rekomendasi.push({
-          title,
-          originalLink: finalOriginalLink,
-          apiDetailLink,
-          thumbnail,
-        });
-      }
-    });
+    if (!rekomendasi.length) {
+      logEmptyParse("GET /rekomendasi", data, {
+        target: BASE_URL,
+        selector: '#Rekomendasi_Komik a[href*="/manga/"], img',
+      });
+    }
 
     res.json(rekomendasi);
   } catch (err) {

--- a/controllers/scraperUtils.js
+++ b/controllers/scraperUtils.js
@@ -1,0 +1,150 @@
+const axios = require("axios");
+
+const BASE_URL = "https://komiku.org";
+const PLACEHOLDER_IMAGE_RE = /\/asset\/img\/lazy\.jpg/i;
+
+const requestHeaders = {
+  "User-Agent":
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36",
+  Accept:
+    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+  "Accept-Language": "id-ID,id;q=0.9,en-US;q=0.8,en;q=0.7",
+  "Cache-Control": "no-cache",
+};
+
+function getAbsoluteUrl(url, baseUrl = BASE_URL) {
+  if (!url || typeof url !== "string") return null;
+
+  const trimmedUrl = url.trim();
+  if (!trimmedUrl || trimmedUrl.startsWith("data:")) return null;
+
+  try {
+    return new URL(trimmedUrl, baseUrl).toString();
+  } catch (error) {
+    return null;
+  }
+}
+
+async function fetchHtml(url, options = {}) {
+  const absoluteUrl = getAbsoluteUrl(url);
+  const { data } = await axios.get(absoluteUrl, {
+    ...options,
+    headers: {
+      ...requestHeaders,
+      Referer: BASE_URL + "/",
+      ...(options.headers || {}),
+    },
+    timeout: options.timeout || 15000,
+  });
+
+  return data;
+}
+
+function normalizeText(value) {
+  return (value || "").replace(/\s+/g, " ").trim();
+}
+
+function cleanTitle(value) {
+  return normalizeText(value)
+    .replace(/^Baca\s+(Komik|Manga|Manhwa|Manhua)?\s*/i, "")
+    .replace(/^Komik\s+/i, "")
+    .trim();
+}
+
+function safeText(root, selector) {
+  if (!root || !selector) return "";
+  return normalizeText(root.find(selector).first().text());
+}
+
+function getSrcsetUrl(srcset) {
+  if (!srcset) return null;
+  const firstCandidate = srcset.split(",")[0]?.trim().split(/\s+/)[0];
+  return firstCandidate || null;
+}
+
+function getImageUrl($, imgElement) {
+  if (!imgElement || !imgElement.length) return null;
+
+  const src =
+    imgElement.attr("data-src") ||
+    imgElement.attr("data-lazy-src") ||
+    imgElement.attr("data-original") ||
+    getSrcsetUrl(imgElement.attr("data-srcset") || imgElement.attr("srcset")) ||
+    imgElement.attr("src");
+
+  return getAbsoluteUrl(src);
+}
+
+function extractMangaSlug(url) {
+  if (!url) return "";
+
+  try {
+    const { pathname } = new URL(url, BASE_URL);
+    return pathname.match(/\/manga\/([^/]+)/i)?.[1] || "";
+  } catch (error) {
+    return String(url).match(/\/manga\/([^/]+)/i)?.[1] || "";
+  }
+}
+
+function extractChapterNumber(url) {
+  if (!url) return "";
+
+  try {
+    const { pathname } = new URL(url, BASE_URL);
+    return (
+      pathname.match(/-chapter-([\d.]+)\/?$/i)?.[1] ||
+      pathname.match(/\/chapter\/([\d.]+)\/?$/i)?.[1] ||
+      pathname.match(/\/([\d.]+)\/?$/i)?.[1] ||
+      ""
+    );
+  } catch (error) {
+    return (
+      String(url).match(/-chapter-([\d.]+)\/?$/i)?.[1] ||
+      String(url).match(/\/([\d.]+)\/?$/i)?.[1] ||
+      ""
+    );
+  }
+}
+
+function extractChapterSlug(url) {
+  if (!url) return "";
+
+  try {
+    const { pathname } = new URL(url, BASE_URL);
+    return pathname.match(/\/([^/]+)-chapter-[^/]+\/?$/i)?.[1] || "";
+  } catch (error) {
+    return String(url).match(/\/([^/]+)-chapter-[^/]+\/?$/i)?.[1] || "";
+  }
+}
+
+function getApiChapterLink(chapterUrl, fallbackMangaSlug = "") {
+  const chapterNumber = extractChapterNumber(chapterUrl);
+  const chapterSlug = fallbackMangaSlug || extractChapterSlug(chapterUrl);
+  return chapterSlug && chapterNumber
+    ? `/baca-chapter/${chapterSlug}/${chapterNumber}`
+    : null;
+}
+
+function logEmptyParse(context, html, extra = {}) {
+  console.error(`Parsing ${context} kosong dari Komiku.`, {
+    ...extra,
+    htmlPreview: normalizeText(html).slice(0, 1200),
+  });
+}
+
+module.exports = {
+  BASE_URL,
+  PLACEHOLDER_IMAGE_RE,
+  requestHeaders,
+  getAbsoluteUrl,
+  fetchHtml,
+  normalizeText,
+  cleanTitle,
+  safeText,
+  getImageUrl,
+  extractMangaSlug,
+  extractChapterNumber,
+  extractChapterSlug,
+  getApiChapterLink,
+  logEmptyParse,
+};

--- a/controllers/searchController.js
+++ b/controllers/searchController.js
@@ -1,113 +1,57 @@
-const express = require("express");
-const router = express.Router();
-const axios = require("axios");
 const cheerio = require("cheerio");
+const {
+  BASE_URL,
+  fetchHtml,
+  getAbsoluteUrl,
+  normalizeText,
+  cleanTitle,
+  getImageUrl,
+  extractMangaSlug,
+  logEmptyParse,
+} = require("./scraperUtils");
 
 const getSearch = async (req, res) => {
   const keyword = req.query.q;
   if (!keyword)
     return res.status(400).json({ error: "Parameter q wajib diisi" });
 
+  const searchUrl = `${BASE_URL}/?s=${encodeURIComponent(
+    keyword
+  )}&post_type=manga`;
+
   try {
-    console.log(`Mencari manga dengan keyword: ${keyword}`);
+    const html = await fetchHtml(searchUrl);
+    const $ = cheerio.load(html);
+    let hasil = parseResults($);
 
-    const searchUrl = `https://komiku.org/?s=${encodeURIComponent(
-      keyword
-    )}&post_type=manga`;
+    if (!hasil.length) {
+      const htmxUrl = $('[hx-get*="post_type=manga"], [data-hx-get*="post_type=manga"]')
+        .first()
+        .attr("hx-get");
 
-    const { data } = await axios.get(searchUrl, {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-        Accept:
-          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-        Referer: "https://komiku.id/",
-        "Cache-Control": "public, max-age=3600", // Cache for 1 hour
-      },
-    });
+      if (htmxUrl) {
+        const htmxHtml = await fetchHtml(htmxUrl, {
+          headers: {
+            "HX-Request": "true",
+            Referer: searchUrl,
+          },
+        });
+        hasil = parseResults(cheerio.load(htmxHtml));
 
-    const $ = cheerio.load(data);
-    let hasil = [];
-
-    const htmxElement = $(".daftar span[hx-get]");
-    let useBackupMethod = false;
-
-    if (htmxElement.length > 0) {
-      const htmxApiUrl = htmxElement.attr("hx-get");
-      console.log("Ditemukan elemen HTMX, melakukan request ke:", htmxApiUrl);
-
-      if (htmxApiUrl) {
-        try {
-          // Request ke API HTMX
-          const htmxResponse = await axios.get(htmxApiUrl, {
-            headers: {
-              "User-Agent":
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-              Accept: "text/html",
-              "HX-Request": "true",
-              Referer: searchUrl,
-            },
+        if (!hasil.length) {
+          logEmptyParse("GET /search htmx", htmxHtml, {
+            target: getAbsoluteUrl(htmxUrl),
+            selector: 'a[href*="/manga/"], img, h3',
           });
-
-          const htmxHtml = htmxResponse.data;
-          const $htmx = cheerio.load(htmxHtml);
-
-          if ($htmx(".bge").length > 0) {
-            console.log("Ditemukan hasil dari API HTMX");
-            parseResults($htmx, hasil);
-          } else {
-            useBackupMethod = true;
-          }
-        } catch (htmxError) {
-          console.error("Error saat mengambil data HTMX:", htmxError.message);
-          useBackupMethod = true;
         }
       } else {
-        useBackupMethod = true;
+        logEmptyParse("GET /search", html, {
+          target: searchUrl,
+          selector: '[hx-get*="post_type=manga"], a[href*="/manga/"]',
+        });
       }
     }
 
-    if (hasil.length === 0 || useBackupMethod) {
-      console.log("Menggunakan metode parsing regular");
-      parseResults($, hasil);
-    }
-
-    if (hasil.length === 0) {
-      console.log(
-        "Tidak ada hasil ditemukan dengan metode standar, mencoba parser generik"
-      );
-
-      $("a").each((i, el) => {
-        if ($(el).attr("href") && $(el).attr("href").includes("/manga/")) {
-          const link = $(el).attr("href");
-          const title = $(el).text().trim() || $(el).find("h3").text().trim();
-
-          if (title && title.length > 3) {
-            const slug = link.replace(/^.*\/manga\//, "").replace(/\/$/, "");
-            let thumbnail = $(el).find("img").attr("src") || "";
-
-            hasil.push({
-              title,
-              slug,
-              href: `/detail-komik/${slug}/`,
-              thumbnail,
-              source: "generic-parser",
-            });
-          }
-        }
-      });
-
-      const slugs = new Set();
-      hasil = hasil.filter((item) => {
-        if (!slugs.has(item.slug)) {
-          slugs.add(item.slug);
-          return true;
-        }
-        return false;
-      });
-    }
-
-    // Status response
     res.json({
       status: true,
       message:
@@ -120,7 +64,7 @@ const getSearch = async (req, res) => {
       data: hasil,
     });
   } catch (err) {
-    console.error("Error:", err);
+    console.error("Error GET /search:", err);
     res.status(500).json({
       status: false,
       message: "Gagal mengambil data",
@@ -129,84 +73,66 @@ const getSearch = async (req, res) => {
   }
 };
 
-function parseResults($, hasil) {
-  $(".bge").each((i, el) => {
-    try {
-      const bgei = $(el).find(".bgei");
-      const kan = $(el).find(".kan");
+function getCardElements($) {
+  const selectors = [
+    '.bge:has(a[href*="/manga/"])',
+    'article:has(a[href*="/manga/"])',
+    'li:has(a[href*="/manga/"])',
+    'div:has(> a[href*="/manga/"]):has(img)',
+  ];
 
-      const mangaLink = bgei.find("a").attr("href") || "";
-      const slug = mangaLink.replace("/manga/", "").replace(/\/$/, "");
+  for (const selector of selectors) {
+    const elements = $(selector).toArray();
+    if (elements.length) return elements;
+  }
 
-      const thumbnail = bgei.find("img").attr("src") || "";
+  return $('a[href*="/manga/"]')
+    .toArray()
+    .map((link) => $(link).closest("article, li, div").get(0))
+    .filter(Boolean);
+}
 
-      const title = kan.find("h3").text().trim();
+function parseResults($) {
+  const hasil = [];
+  const seen = new Set();
 
-      const altTitle = kan.find(".judul2").text().trim();
+  getCardElements($).forEach((el) => {
+    const card = $(el);
+    const mangaLinkElement =
+      card.find('h1 a[href*="/manga/"], h2 a[href*="/manga/"], h3 a[href*="/manga/"], h4 a[href*="/manga/"]').first()
+        .length
+        ? card.find('h1 a[href*="/manga/"], h2 a[href*="/manga/"], h3 a[href*="/manga/"], h4 a[href*="/manga/"]').first()
+        : card.find('a[href*="/manga/"]').first();
+    const mangaLink = getAbsoluteUrl(mangaLinkElement.attr("href"));
+    const slug = extractMangaSlug(mangaLink);
+    if (!slug || seen.has(slug)) return;
 
-      const description = kan.find("p").text().trim();
+    const img = card.find('a[href*="/manga/"] img, img').first();
+    const type =
+      normalizeText(card.find(".tpe1_inf b, .tpe1_inf strong, b, strong").first().text()) ||
+      "";
+    const typeGenreText = normalizeText(card.find(".tpe1_inf").first().text());
+    const title =
+      cleanTitle(card.find("h3, h2, h4").first().text()) ||
+      cleanTitle(mangaLinkElement.attr("title")) ||
+      cleanTitle(img.attr("alt"));
 
-      const type = bgei.find(".tpe1_inf b").text().trim();
+    if (!title) return;
+    seen.add(slug);
 
-      const genre = bgei.find(".tpe1_inf").text().replace(type, "").trim();
-
-      const chapterAwal = kan
-        .find(".new1")
-        .first()
-        .find("span:last-child")
-        .text()
-        .trim();
-      const chapterTerbaru = kan
-        .find(".new1")
-        .last()
-        .find("span:last-child")
-        .text()
-        .trim();
-
-      const href = `/detail-komik/${slug}/`;
-
-      const chapterAwalLink =
-        kan.find(".new1").first().find("a").attr("href") || "";
-      const chapterTerbaruLink =
-        kan.find(".new1").last().find("a").attr("href") || "";
-
-      const formatChapterLink = (link) => {
-        if (!link) return "";
-
-        const cleanLink = link.replace(/^https?:\/\/komiku\.id/i, "");
-
-        const linkWithSlash = cleanLink.startsWith("/")
-          ? cleanLink
-          : `/${cleanLink}`;
-
-        const chapterSlug = linkWithSlash.replace(/^\//, "");
-
-        return `/baca-chapter/${chapterSlug}`;
-      };
-      hasil.push({
-        title,
-        altTitle: altTitle || null,
-        slug,
-        href,
-        thumbnail,
-        type,
-        genre: genre || null,
-        description,
-        // chapter: {
-        //   awal: {
-        //     number: chapterAwal,
-        //     link: formatChapterLink(chapterAwalLink),
-        //   },
-        //   terbaru: {
-        //     number: chapterTerbaru,
-        //     link: formatChapterLink(chapterTerbaruLink),
-        //   },
-        // },
-      });
-    } catch (error) {
-      console.log("Error parsing manga item:", error);
-    }
+    hasil.push({
+      title,
+      altTitle: normalizeText(card.find(".judul2").first().text()) || null,
+      slug,
+      href: `/detail-komik/${slug}/`,
+      thumbnail: getImageUrl($, img) || "",
+      type,
+      genre: typeGenreText.replace(type, "").trim() || null,
+      description: normalizeText(card.find("p").first().text()),
+    });
   });
+
+  return hasil;
 }
 
 module.exports = { getSearch };

--- a/controllers/terbaruControllers.js
+++ b/controllers/terbaruControllers.js
@@ -1,143 +1,233 @@
-// File: routes/terbaru.js (atau nama file yang Anda inginkan)
-
-const express = require("express");
-const axios = require("axios");
 const cheerio = require("cheerio");
-const router = express.Router();
+const {
+  BASE_URL,
+  PLACEHOLDER_IMAGE_RE,
+  getAbsoluteUrl,
+  fetchHtml,
+  normalizeText,
+  cleanTitle,
+  extractMangaSlug,
+  extractChapterNumber,
+  logEmptyParse,
+} = require("./scraperUtils");
 
-const URL_KOMIKU = "https://komiku.org/";
+function parseTypeFromText(...values) {
+  const joinedValue = values.map(normalizeText).filter(Boolean).join(" ");
+  const typeMatch = joinedValue.match(/\b(Manga|Manhwa|Manhua)\b/i);
+
+  if (!typeMatch) return "Unknown";
+
+  const type = typeMatch[1].toLowerCase();
+  return type.charAt(0).toUpperCase() + type.slice(1);
+}
+
+function parseGenreAndUpdateTime($, card) {
+  const metadataTexts = [];
+
+  card.find("span, p, small").each((_, el) => {
+    const text = normalizeText($(el).text());
+    if (
+      text &&
+      !/^up\s*\d+/i.test(text) &&
+      !/^chapter\b/i.test(text) &&
+      !/^(manga|manhwa|manhua)$/i.test(text)
+    ) {
+      metadataTexts.push(text);
+    }
+  });
+
+  const metadataText =
+    metadataTexts.find((text) => /lalu|views|·|\|/i.test(text)) ||
+    metadataTexts[0] ||
+    "";
+
+  const parts = metadataText
+    .split(/\s*[·|]\s*/)
+    .map(normalizeText)
+    .filter(Boolean);
+
+  const updateTime =
+    parts.find((part) => /\blalu\b/i.test(part)) ||
+    metadataText.match(/((?:\d+|se)?\s*\w+\s+lalu)/i)?.[1] ||
+    "Unknown";
+
+  const genre =
+    parts.find((part) => !/\blalu\b|views?/i.test(part)) ||
+    metadataText.replace(updateTime, "").replace(/views?/i, "").trim() ||
+    "Unknown";
+
+  return {
+    genre: genre || "Unknown",
+    updateTime: updateTime || "Unknown",
+  };
+}
+
+function findTerbaruSection($) {
+  const directSection = $("#Terbaru");
+  if (directSection.length) return directSection.first();
+
+  const sections = $("section, main, div")
+    .toArray()
+    .filter((el) => {
+      const element = $(el);
+      const headingText = normalizeText(
+        element.children("h1,h2,h3,h4,header").first().text()
+      );
+      const hasUpdateHeading = /terbaru|update/i.test(headingText);
+      const hasCards =
+        element.find('a[href*="/manga/"]').length > 0 &&
+        element.find('a[href*="chapter"]').length > 0;
+
+      return hasUpdateHeading && hasCards;
+    });
+
+  return sections.length ? $(sections[0]) : null;
+}
+
+function getCandidateCards($, section) {
+  const selectors = [
+    "article",
+    'li:has(a[href*="/manga/"]):has(a[href*="chapter"])',
+    'div:has(> a[href*="/manga/"]):has(a[href*="chapter"])',
+    'div:has(a[href*="/manga/"]):has(a[href*="chapter"]):has(img)',
+  ];
+
+  const root = section && section.length ? section : $.root();
+
+  for (const selector of selectors) {
+    const cards = root
+      .find(selector)
+      .toArray()
+      .filter((el) => {
+        const card = $(el);
+        return (
+          card.find('a[href*="/manga/"]').length > 0 &&
+          card.find('a[href*="chapter"]').length > 0 &&
+          card.find("img").length > 0
+        );
+      });
+
+    if (cards.length) return cards;
+  }
+
+  return $('a[href*="/manga/"]')
+    .toArray()
+    .map((link) => $(link).closest("article, li, div").get(0))
+    .filter(Boolean);
+}
+
+function parseCard($, cardElement) {
+  const card = $(cardElement);
+  const mangaLinkElement =
+    card.find('h1 a[href*="/manga/"], h2 a[href*="/manga/"], h3 a[href*="/manga/"], h4 a[href*="/manga/"]').first()
+      .length
+      ? card.find('h1 a[href*="/manga/"], h2 a[href*="/manga/"], h3 a[href*="/manga/"], h4 a[href*="/manga/"]').first()
+      : card.find('a[href*="/manga/"]').filter((_, el) => normalizeText($(el).text())).first()
+          .length
+        ? card.find('a[href*="/manga/"]').filter((_, el) => normalizeText($(el).text())).first()
+        : card.find('a[href*="/manga/"]').first();
+
+  const imageElement =
+    card.find('a[href*="/manga/"] img').first().length
+      ? card.find('a[href*="/manga/"] img').first()
+      : card.find("img").first();
+
+  const originalLink = getAbsoluteUrl(mangaLinkElement.attr("href"));
+  const title =
+    cleanTitle(mangaLinkElement.text()) ||
+    cleanTitle(mangaLinkElement.attr("title")) ||
+    cleanTitle(imageElement.attr("alt")) ||
+    "Judul Tidak Tersedia";
+
+  const thumbnailSource =
+    imageElement.attr("data-src") ||
+    imageElement.attr("data-lazy-src") ||
+    imageElement.attr("data-original") ||
+    imageElement.attr("src");
+  const thumbnail = getAbsoluteUrl(thumbnailSource);
+
+  const latestChapterElement =
+    card.find('a[href*="chapter"]').filter((_, el) => normalizeText($(el).text())).first()
+      .length
+      ? card.find('a[href*="chapter"]').filter((_, el) => normalizeText($(el).text())).first()
+      : card.find('a[href*="chapter"]').first();
+  const latestChapterTitle =
+    normalizeText(latestChapterElement.text()) ||
+    normalizeText(latestChapterElement.attr("title"));
+  const latestChapterLink = getAbsoluteUrl(latestChapterElement.attr("href"));
+  const { genre, updateTime } = parseGenreAndUpdateTime($, card);
+  const updateCountText =
+    normalizeText(card.find("span").filter((_, el) => /^up\s*\d+/i.test(normalizeText($(el).text()))).first().text()) ||
+    normalizeText(card.text()).match(/\bUp\s*\d+\b/i)?.[0] ||
+    "";
+  const type = parseTypeFromText(
+    mangaLinkElement.attr("title"),
+    imageElement.attr("alt"),
+    card.text()
+  );
+  const isColored = /\b(berwarna|color|colored)\b/i.test(card.text());
+  const mangaSlug = extractMangaSlug(originalLink);
+  const chapterNumber = extractChapterNumber(latestChapterLink);
+
+  return {
+    title,
+    originalLink,
+    thumbnail,
+    type,
+    genre,
+    updateTime,
+    latestChapterTitle,
+    latestChapterLink,
+    isColored,
+    updateCountText,
+    mangaSlug,
+    apiDetailLink: mangaSlug ? `/detail-komik/${mangaSlug}` : null,
+    apiChapterLink:
+      mangaSlug && chapterNumber
+        ? `/baca-chapter/${mangaSlug}/${chapterNumber}`
+        : null,
+  };
+}
+
+function parseTerbaruHtml(html) {
+  const $ = cheerio.load(html);
+  const section = findTerbaruSection($);
+  const candidateCards = getCandidateCards($, section);
+  const seen = new Set();
+
+  return candidateCards
+    .map((card) => parseCard($, card))
+    .filter((item) => {
+      const hasRequiredData =
+        item.title &&
+        item.title !== "Judul Tidak Tersedia" &&
+        item.originalLink &&
+        item.thumbnail &&
+        !PLACEHOLDER_IMAGE_RE.test(item.thumbnail);
+
+      const key = `${item.mangaSlug}:${item.latestChapterLink || ""}`;
+      if (!hasRequiredData || seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+}
+
 const getTerbaru = async (req, res) => {
   try {
-    const { data } = await axios.get(URL_KOMIKU, {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-        Accept:
-          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.5",
-        "Cache-Control": "public, max-age=3600", // Cache for 1 hour
-      },
-      timeout: 10000, // Opsional: 10 detik timeout
-    });
+    const data = await fetchHtml(BASE_URL);
 
-    const $ = cheerio.load(data);
-    const komikTerbaru = [];
+    const komikTerbaru = parseTerbaruHtml(data);
 
-    $("#Terbaru div.ls4w article.ls4").each((i, el) => {
-      const element = $(el);
+    if (!komikTerbaru.length) {
+      logEmptyParse("GET /terbaru", data, { target: BASE_URL });
 
-      const linkElement = element.find(".ls4v > a").first();
-      const imgElement = linkElement.find("img");
-      const detailElement = element.find(".ls4j");
-
-      const titleFromImgAlt = imgElement
-        .attr("alt")
-        ?.replace(/^Baca (Manga|Manhwa|Manhua)\s+/i, "")
-        .trim();
-      const titleFromH3 = detailElement.find("h3 > a").text().trim();
-      const title = titleFromH3 || titleFromImgAlt || "Judul Tidak Tersedia";
-
-      const originalLinkPath = linkElement.attr("href");
-      const originalLink = originalLinkPath?.startsWith("http")
-        ? originalLinkPath
-        : originalLinkPath
-        ? `${URL_KOMIKU.slice(0, -1)}${originalLinkPath}`
-        : null;
-
-      let thumbnail = imgElement.attr("data-src");
-      if (!thumbnail || thumbnail.trim() === "") {
-        thumbnail = imgElement.attr("src");
-      }
-      // Opsional: Membersihkan URL thumbnail jika ada parameter yang tidak diinginkan (misal ?resize=)
-      // if (thumbnail && thumbnail.includes('?')) {
-      //   thumbnail = thumbnail.split('?')[0];
-      // }
-
-      const typeGenreTimeString = detailElement.find("span.ls4s").text().trim();
-      let type = "Unknown";
-      let genre = "Unknown";
-      let updateTime = "Unknown";
-
-      const typeMatch = typeGenreTimeString.match(/^(Manga|Manhwa|Manhua)/i);
-      if (typeMatch) {
-        type = typeMatch[0];
-        const restOfString = typeGenreTimeString.substring(type.length).trim();
-        const timeMatch = restOfString.match(/(.+?)\s+([\d\w\s]+lalu)$/i);
-        if (timeMatch) {
-          genre = timeMatch[1].trim();
-          updateTime = timeMatch[2].trim();
-        } else {
-          genre = restOfString;
-        }
-      } else {
-        const parts = typeGenreTimeString.split(/\s+/);
-        if (parts.length >= 2) {
-          if (parts[parts.length - 1] === "lalu" && parts.length > 2) {
-            updateTime = parts.slice(-2).join(" ");
-            genre = parts.slice(0, -2).join(" ");
-          } else {
-            genre = typeGenreTimeString;
-          }
-        } else {
-          genre = typeGenreTimeString;
-        }
-      }
-
-      const latestChapterElement = detailElement.find("a.ls24");
-      const latestChapterTitle = latestChapterElement.text().trim();
-      const latestChapterLinkPath = latestChapterElement.attr("href");
-      const latestChapterLink = latestChapterLinkPath?.startsWith("http")
-        ? latestChapterLinkPath
-        : latestChapterLinkPath
-        ? `${URL_KOMIKU.slice(0, -1)}${latestChapterLinkPath}`
-        : null;
-
-      const isColored = element.find(".ls4v span.warna").length > 0;
-      const updateCountText = element.find(".ls4v span.up").text().trim();
-
-      let mangaSlug = "";
-      if (originalLinkPath) {
-        const slugMatches = originalLinkPath.match(/\/manga\/([^/]+)/);
-        if (slugMatches && slugMatches[1]) {
-          mangaSlug = slugMatches[1];
-        }
-      }
-      const apiDetailLink = mangaSlug ? `/detail-komik/${mangaSlug}` : null;
-
-      let apiChapterLink = null;
-      if (latestChapterLinkPath && mangaSlug) {
-        const chapterNumMatch =
-          latestChapterLinkPath.match(/-chapter-([\d.]+)\/?$/i) ||
-          latestChapterLinkPath.match(/\/([\d.]+)\/?$/i);
-        if (chapterNumMatch && chapterNumMatch[1]) {
-          const chapterNumber = chapterNumMatch[1];
-          apiChapterLink = `/baca-chapter/${mangaSlug}/${chapterNumber}`;
-        }
-      }
-
-      if (
-        title &&
-        title !== "Judul Tidak Tersedia" &&
-        thumbnail &&
-        originalLink
-      ) {
-        komikTerbaru.push({
-          title,
-          originalLink,
-          thumbnail,
-          type,
-          genre,
-          updateTime,
-          latestChapterTitle,
-          latestChapterLink,
-          isColored,
-          updateCountText,
-          mangaSlug,
-          apiDetailLink,
-          apiChapterLink,
-        });
-      }
-    });
+      return res.status(502).json({
+        error:
+          "Gagal parsing daftar komik terbaru dari Komiku: hasil kosong.",
+        detail:
+          "Struktur HTML Komiku kemungkinan berubah atau halaman target tidak memuat daftar terbaru.",
+      });
+    }
 
     res.json(komikTerbaru);
   } catch (err) {
@@ -149,4 +239,4 @@ const getTerbaru = async (req, res) => {
   }
 };
 
-module.exports = { getTerbaru };
+module.exports = { getTerbaru, getAbsoluteUrl };

--- a/routes/genre-detail.js
+++ b/routes/genre-detail.js
@@ -90,7 +90,7 @@ const { handleGenreRequest } = require("../controllers/genreDetailController");
  *                                 example: "https://komiku.org/the-rebirth-of-the-heros-partys-archmage-chapter-00-1/"
  *                               apiLink:
  *                                 type: string
- *                                 example: "/chapter/the-rebirth-of-the-heros-partys-archmage-chapter-00-1/"
+ *                                 example: "/baca-chapter/the-rebirth-of-the-heros-partys-archmage/00-1"
  *                           latest:
  *                             type: object
  *                             properties:
@@ -99,7 +99,7 @@ const { handleGenreRequest } = require("../controllers/genreDetailController");
  *                                 example: "Chapter 107"
  *                               link:
  *                                 type: string
- *                                 example: "https://mangaverse.my.id/the-rebirth-of-the-heros-partys-archmage-chapter-107/"
+ *                                 example: "https://komiku.org/the-rebirth-of-the-heros-partys-archmage-chapter-107/"
  *                               apiLink:
  *                                 type: string
  *                                 example: "/baca-chapter/the-rebirth-of-the-heros-partys-archmage/107"
@@ -108,7 +108,7 @@ const { handleGenreRequest } = require("../controllers/genreDetailController");
  *                   properties:
  *                     targetUrl:
  *                       type: string
- *                       example: "https://api.komiku.org/genre/action/page/1/"
+ *                       example: "https://komiku.org/genre/action/"
  *                     elementsFound:
  *                       type: integer
  *                       example: 10
@@ -210,7 +210,7 @@ const { handleGenreRequest } = require("../controllers/genreDetailController");
  *                                 example: "https://komiku.org/the-tale-of-the-skeleton-messenger-chapter-1/"
  *                               apiLink:
  *                                 type: string
- *                                 example: "/chapter/the-tale-of-the-skeleton-messenger-chapter-1/"
+ *                                 example: "/baca-chapter/the-tale-of-the-skeleton-messenger/1"
  *                           latest:
  *                             type: object
  *                             properties:
@@ -219,7 +219,7 @@ const { handleGenreRequest } = require("../controllers/genreDetailController");
  *                                 example: "Chapter 11"
  *                               link:
  *                                 type: string
- *                                 example: "https://mangaverse.my.id/the-tale-of-the-skeleton-messenger-chapter-11/"
+ *                                 example: "https://komiku.org/the-tale-of-the-skeleton-messenger-chapter-11/"
  *                               apiLink:
  *                                 type: string
  *                                 example: "/baca-chapter/the-tale-of-the-skeleton-messenger/11"
@@ -228,7 +228,7 @@ const { handleGenreRequest } = require("../controllers/genreDetailController");
  *                   properties:
  *                     targetUrl:
  *                       type: string
- *                       example: "https://api.komiku.org/genre/action/page/2/"
+ *                       example: "https://komiku.org/genre/action/page/2/"
  *                     elementsFound:
  *                       type: integer
  *                       example: 10


### PR DESCRIPTION
## Summary
- Move Komiku scrapers away from blocked legacy Komiku endpoints and toward public `https://komiku.org` pages.
- Add shared scraper helpers for absolute URLs, HTML fetching, image extraction, manga slugs, chapter numbers, and empty-parse diagnostics.
- Stabilize latest, detail, chapter reader, search, library, genre, colored, popular, recommendations, and genre listing controllers while preserving existing response fields.

## Why
Some networks block or misroute older Komiku data/API endpoints, causing SSL mismatch and empty scraper responses. Several scrapers also depended on brittle CSS classes and manual URL concatenation.

## Validation
- `for f in controllers/*.js; do node -c "$f" || exit 1; done`
- Previously verified local endpoints return valid non-empty JSON for `/terbaru`, `/detail-komik/komen-fuufu`, `/baca-chapter/komen-fuufu/19`, `/search?q=one`, `/pustaka`, `/genre/action`, `/genre/action/page/2`, `/berwarna`, `/komik-populer`, `/rekomendasi`, `/genre-all`, and `/genre-rekomendasi`.
